### PR TITLE
fixed infinispan location

### DIFF
--- a/sm-core/src/main/resources/spring/shopizer-search.xml
+++ b/sm-core/src/main/resources/spring/shopizer-search.xml
@@ -15,7 +15,7 @@
 	<bean id="serverConfiguration" class="com.shopizer.search.utils.ServerConfiguration">
 		<property name="clusterName" value="shopizer"/>
 		<!-- local (embedded version, will create new indexes in the working directory) or remote (requires existing server) -->
-		<property name="mode" value="local"/>
+		<property name="mode" value="remote"/>
 		<!-- http interface to ES server -->
 		<property name="clusterHost" value="http://localhost"/>
 		<property name="clusterPort" value="9200"/>

--- a/sm-core/src/main/resources/spring/shopizer-search.xml
+++ b/sm-core/src/main/resources/spring/shopizer-search.xml
@@ -15,7 +15,7 @@
 	<bean id="serverConfiguration" class="com.shopizer.search.utils.ServerConfiguration">
 		<property name="clusterName" value="shopizer"/>
 		<!-- local (embedded version, will create new indexes in the working directory) or remote (requires existing server) -->
-		<property name="mode" value="remote"/>
+		<property name="mode" value="local"/>
 		<!-- http interface to ES server -->
 		<property name="clusterHost" value="http://localhost"/>
 		<property name="clusterPort" value="9200"/>


### PR DESCRIPTION
in 2.0.2 default is "local" but in 2.0.3 "remote" and need a running elasticsearch server
this commit reverts that behaviour, so that no running elasticsearch server is needed