### PR TITLE
Add to cart was failing due to the jsp it was loading didn't have the showTemplateLoading and hideTemplateLoading methods

### DIFF
--- a/sm-shop/src/main/webapp/pages/shop/templates/exoticamobilia/sections/shopLinks.jsp
+++ b/sm-shop/src/main/webapp/pages/shop/templates/exoticamobilia/sections/shopLinks.jsp
@@ -31,7 +31,20 @@
     	<!-- generic and common css file -->
     	<link href="<c:url value="/resources/css/sm.css" />" rel="stylesheet">
     	<link href="<c:url value="/resources/css/showLoading.css" />" rel="stylesheet">
-    
+
+
+		<script type="text/javascript">
+			//show overlay wait
+			function showTemplateLoading(element) {
+				$.LoadingOverlay("show");
+			}
+
+			function hideTemplateLoading(element) {
+				$.LoadingOverlay("hide", true);
+			}
+
+		</script>
+
     	<!-- ////////////// -->
     	
 


### PR DESCRIPTION
I was getting the following error when using exoticamobilia theme

shop-functions.js:24 Uncaught ReferenceError: showTemplateLoading is not defined
    at showSMLoading (shop-functions.js:24)
    at addToCart (shop-minicart.js:50)
    at HTMLButtonElement.<anonymous> (shop-minicart.js:37)
    at HTMLButtonElement.dispatch (jquery-1.11.1.min.js:3)
    at HTMLButtonElement.r.handle (jquery-1.11.1.min.js:3)