### PR TITLE
Bypass unnecessary getByCode query

### DIFF
--- a/sm-shop/src/main/java/com/salesmanager/shop/populator/customer/CustomerPopulator.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/populator/customer/CustomerPopulator.java
@@ -229,7 +229,9 @@ public class CustomerPopulator extends
 			}
 			
 			if(target.getDefaultLanguage()==null) {
-				Language lang = languageService.getByCode(source.getLanguage());
+				Language lang = source.getLanguage() == null ?
+						null : languageService.getByCode(source.getLanguage());
+				
 				if(lang==null) {
 					lang = store.getDefaultLanguage();
 				}


### PR DESCRIPTION
When language code is not available(==null), bypassed the unnecessary `getByCode` query.

Relates to https://github.com/shopizer-ecommerce/shopizer/issues/378.