### PR TITLE
Add Index on TAX_CLASS.CODE

### DIFF
--- a/sm-core-model/src/main/java/com/salesmanager/core/model/tax/taxclass/TaxClass.java
+++ b/sm-core-model/src/main/java/com/salesmanager/core/model/tax/taxclass/TaxClass.java
@@ -9,6 +9,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
@@ -25,8 +26,9 @@ import com.salesmanager.core.model.merchant.MerchantStore;
 import com.salesmanager.core.model.tax.taxrate.TaxRate;
 
 @Entity
-@Table(name = "TAX_CLASS", schema = SchemaConstant.SALESMANAGER_SCHEMA,uniqueConstraints=
-    @UniqueConstraint(columnNames = {"MERCHANT_ID", "TAX_CLASS_CODE"}) )
+@Table(name = "TAX_CLASS", schema = SchemaConstant.SALESMANAGER_SCHEMA,
+		indexes = { @Index(name="TAX_CLASS_CODE_IDX",columnList = "TAX_CLASS_CODE")},
+		uniqueConstraints = @UniqueConstraint(columnNames = {"MERCHANT_ID", "TAX_CLASS_CODE"}) )
 public class TaxClass extends SalesManagerEntity<Long, TaxClass> {
 	private static final long serialVersionUID = -325750148480212355L;
 	


### PR DESCRIPTION
Adding index on table `TAX_CLASS` column `CODE` might speed up the underlying query issued via `TaxClassService#getByCode(java.lang.String)`. See #379  