### PR TITLE
Add Index on LANGUAGE.CODE

### DIFF
--- a/sm-core-model/src/main/java/com/salesmanager/core/model/reference/language/Language.java
+++ b/sm-core-model/src/main/java/com/salesmanager/core/model/reference/language/Language.java
@@ -11,6 +11,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -24,7 +25,7 @@ import com.salesmanager.core.model.merchant.MerchantStore;
 
 @Entity
 @EntityListeners(value = AuditListener.class)
-@Table(name = "LANGUAGE", schema = SchemaConstant.SALESMANAGER_SCHEMA)
+@Table(name = "LANGUAGE", schema = SchemaConstant.SALESMANAGER_SCHEMA, indexes = { @Index(name="CODE_IDX", columnList = "CODE")})
 @Cacheable
 public class Language extends SalesManagerEntity<Integer, Language> implements Auditable {
   private static final long serialVersionUID = -7676627812941330669L;


### PR DESCRIPTION
Adding index on table `LANGUAGE` column `CODE` might speed up the underlying query issued via `LanguageService#getByCode`. See #381   