### PR TITLE
Add a dedicated query to reduce the amount of unnecessary joined table for product

### DIFF
--- a/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryCustom.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryCustom.java
@@ -35,6 +35,7 @@ public interface ProductRepositoryCustom {
 				Locale locale);
 
 		Product getById(Long productId);
+	  Product getProductWithOnlyMerchantStoreById(Long productId);
 		Product getById(Long productId, MerchantStore merchant);
 
 		Product getByCode(String productCode, Language language);

--- a/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
@@ -5,10 +5,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import javax.persistence.EntityManager;
-import javax.persistence.NonUniqueResultException;
-import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
+import javax.persistence.*;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -40,7 +38,23 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 	  return this.get(productId, null);
 	}
 
-	    private Product get(Long productId, MerchantStore merchant) {
+	@Override
+	public Product getProductWithOnlyMerchantStoreById(Long productId) {
+		final String hql = "select distinct p from Product as p " +
+				"join fetch p.merchantStore merch " +
+				"where p.id=:pid";
+
+		final Query q = this.em.createQuery(hql);
+		q.setParameter("pid", productId);
+
+		try {
+			return (Product)q.getSingleResult();
+		} catch (NoResultException ignored) {
+			return null;
+		}
+  }
+
+	private Product get(Long productId, MerchantStore merchant) {
 	        
 	        try {
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductService.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductService.java
@@ -40,6 +40,7 @@ public interface ProductService extends SalesManagerEntityService<Long, Product>
 
 	Product getBySeUrl(MerchantStore store, String seUrl, Locale locale);
 
+	Product getProductWithOnlyMerchantStoreById(Long productId);
 	/**
 	 * Get a product by sku (code) field  and the language
 	 * @param productCode

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductServiceImpl.java
@@ -113,6 +113,11 @@ public class ProductServiceImpl extends SalesManagerEntityServiceImpl<Long, Prod
 	public Product getById(Long productId) {
 		return productRepository.getById(productId);
 	}
+
+	@Override
+	public Product getProductWithOnlyMerchantStoreById(Long productId) {
+		return productRepository.getProductWithOnlyMerchantStoreById(productId);
+	}
 	
 	@Override
 	public List<Product> getProducts(List<Long> categoryIds, Language language) throws ServiceException {

--- a/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/products/ProductReviewController.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/products/ProductReviewController.java
@@ -104,7 +104,7 @@ public class ProductReviewController {
 		
 		try {
 
-			product = productService.getById(productId);
+			product = productService.getProductWithOnlyMerchantStoreById(productId);
 
 			
 			if(product==null) {


### PR DESCRIPTION
Implemented a `getProductWithOnlyMerchantStoreById` for the business logic in [ProductReviewController.java](https://github.com/shopizer-ecommerce/shopizer/blob/2.8.0/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/products/ProductReviewController.java), which is significantly simpler and much performant than the originally issued query.

Relates to https://github.com/shopizer-ecommerce/shopizer/issues/385.