### PR TITLE
#414 - db cleanup before junit tests 

### DIFF
--- a/sm-core/pom.xml
+++ b/sm-core/pom.xml
@@ -246,4 +246,25 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<tasks>
+								<delete file="SALESMANAGER-TEST.h2.db"/>
+							</tasks>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/sm-shop/pom.xml
+++ b/sm-shop/pom.xml
@@ -168,6 +168,22 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<delete file="SALESMANAGER-TEST.h2.db"/>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>


### PR DESCRIPTION
delete SALESMANAGER-TEST.h2.db from sm-core and sm-shop before executing tests