### PR TITLE
gcp cloud storage

### DIFF
--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/ContentAssetsManager.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/ContentAssetsManager.java
@@ -1,9 +1,87 @@
 package com.salesmanager.core.business.modules.cms.content;
 
+import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
+import com.salesmanager.core.business.constants.Constants;
 import com.salesmanager.core.business.modules.cms.common.AssetsManager;
+import com.salesmanager.core.business.modules.cms.impl.CMSManager;
+import com.salesmanager.core.model.content.FileContentType;
+import com.salesmanager.core.model.content.OutputContentFile;
 
-public interface ContentAssetsManager
-    extends AssetsManager, FileGet, FilePut, FileRemove, Serializable {
+import org.apache.commons.lang3.StringUtils;
+
+public interface ContentAssetsManager extends AssetsManager, FileGet, FilePut, FileRemove, Serializable {
+    public static final char UNIX_SEPARATOR = '/';
+    public static final char WINDOWS_SEPARATOR = '\\';
+    public static String DEFAULT_BUCKET_NAME = "shopizer";
+    public static String DEFAULT_REGION_NAME = "us-east-1";
+    public static final String ROOT_NAME = "files";
+
+    CMSManager getCmsManager();
+
+    default String bucketName() {
+        String name = getCmsManager().getRootName();
+        if (StringUtils.isBlank(name)) {
+            name = DEFAULT_BUCKET_NAME;
+        }
+        return name;
+    }
+
+    default String nodePath(String store, FileContentType type) {
+
+        StringBuilder builder = new StringBuilder();
+        String root = nodePath(store);
+        builder.append(root);
+        if (type != null && !type.IMAGE.name().equals(type.name()) && !type.STATIC_FILE.name().equals(type.name())) {
+            builder.append(type.name()).append(Constants.SLASH);
+        }
+
+        return builder.toString();
+
+    }
+
+    default String nodePath(String store) {
+
+        StringBuilder builder = new StringBuilder();
+        builder.append(ROOT_NAME).append(Constants.SLASH).append(store).append(Constants.SLASH);
+        return builder.toString();
+
+    }
+
+    default OutputContentFile getOutputContentFile(byte[] byteArray) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(byteArray.length);
+        baos.write(byteArray, 0, byteArray.length);
+        OutputContentFile ct = new OutputContentFile();
+        ct.setFile(baos);
+        return ct;
+    }
+
+    default boolean isInsideSubFolder(String key) {
+        int c = StringUtils.countMatches(key, Constants.SLASH);
+        if (c > 2) {
+          return true;
+        }
+    
+        return false;
+      }
+
+      default String getName(String filename) {
+        if (filename == null) {
+          return null;
+        }
+        int index = indexOfLastSeparator(filename);
+        return filename.substring(index + 1);
+      }
+    
+      default int indexOfLastSeparator(String filename) {
+        if (filename == null) {
+          return -1;
+        }
+        int lastUnixPos = filename.lastIndexOf(UNIX_SEPARATOR);
+        int lastWindowsPos = filename.lastIndexOf(WINDOWS_SEPARATOR);
+        return Math.max(lastUnixPos, lastWindowsPos);
+      }
+    
+    
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/StaticContentFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/StaticContentFileManagerImpl.java
@@ -6,10 +6,10 @@ package com.salesmanager.core.business.modules.cms.content;
 import java.util.List;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.content.infinispan.CmsStaticContentFileManagerImpl;
+import com.salesmanager.core.business.modules.cms.impl.CMSManager;
 import com.salesmanager.core.model.content.FileContentType;
 import com.salesmanager.core.model.content.InputContentFile;
 import com.salesmanager.core.model.content.OutputContentFile;
-
 
 /**
  * @author Umesh Awasthi
@@ -25,8 +25,6 @@ public class StaticContentFileManagerImpl extends StaticContentFileManager {
   private FileGet getFile;
   private FileRemove removeFile;
 
-
-
   @Override
   public void addFile(final String merchantStoreCode, final InputContentFile inputStaticContentData)
       throws ServiceException {
@@ -35,38 +33,36 @@ public class StaticContentFileManagerImpl extends StaticContentFileManager {
   }
 
   /**
-   * Implementation for add static data files. This method will called respected add files method of
-   * underlying CMSStaticContentManager. For CMS Content files
-   * {@link CmsStaticContentFileManagerImpl} will take care of adding given content images with
-   * Infinispan cache.
+   * Implementation for add static data files. This method will called respected
+   * add files method of underlying CMSStaticContentManager. For CMS Content files
+   * {@link CmsStaticContentFileManagerImpl} will take care of adding given
+   * content images with Infinispan cache.
    * 
-   * @param merchantStoreCode merchant store.
+   * @param merchantStoreCode          merchant store.
    * @param inputStaticContentDataList Input content images
    * @throws ServiceException
    */
   @Override
-  public void addFiles(final String merchantStoreCode,
-      final List<InputContentFile> inputStaticContentDataList) throws ServiceException {
+  public void addFiles(final String merchantStoreCode, final List<InputContentFile> inputStaticContentDataList)
+      throws ServiceException {
     uploadFile.addFiles(merchantStoreCode, inputStaticContentDataList);
   }
 
   @Override
-  public void removeFile(final String merchantStoreCode, final FileContentType staticContentType,
-      final String fileName) throws ServiceException {
+  public void removeFile(final String merchantStoreCode, final FileContentType staticContentType, final String fileName)
+      throws ServiceException {
     removeFile.removeFile(merchantStoreCode, staticContentType, fileName);
 
   }
 
-
   @Override
-  public OutputContentFile getFile(String merchantStoreCode, FileContentType fileContentType,
-      String contentName) throws ServiceException {
+  public OutputContentFile getFile(String merchantStoreCode, FileContentType fileContentType, String contentName)
+      throws ServiceException {
     return getFile.getFile(merchantStoreCode, fileContentType, contentName);
   }
 
   @Override
-  public List<String> getFileNames(String merchantStoreCode, FileContentType fileContentType)
-      throws ServiceException {
+  public List<String> getFileNames(String merchantStoreCode, FileContentType fileContentType) throws ServiceException {
     return getFile.getFileNames(merchantStoreCode, fileContentType);
   }
 
@@ -80,8 +76,6 @@ public class StaticContentFileManagerImpl extends StaticContentFileManager {
   public void removeFiles(String merchantStoreCode) throws ServiceException {
     removeFile.removeFiles(merchantStoreCode);
   }
-
-
 
   public void setRemoveFile(FileRemove removeFile) {
     this.removeFile = removeFile;
@@ -107,5 +101,9 @@ public class StaticContentFileManagerImpl extends StaticContentFileManager {
     return uploadFile;
   }
 
+  @Override
+  public CMSManager getCmsManager() {
+    return null;
+  }
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/aws/S3StaticContentAssetsManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/aws/S3StaticContentAssetsManagerImpl.java
@@ -20,7 +20,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.salesmanager.core.business.constants.Constants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.content.ContentAssetsManager;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
@@ -36,21 +35,10 @@ import com.salesmanager.core.model.content.OutputContentFile;
  */
 public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
 
-  /**
-   * 
-   */
   private static final long serialVersionUID = 1L;
 
-  private static final char UNIX_SEPARATOR = '/';
-  private static final char WINDOWS_SEPARATOR = '\\';
+  private static final Logger LOGGER = LoggerFactory.getLogger(S3StaticContentAssetsManagerImpl.class);
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(S3StaticContentAssetsManagerImpl.class);
-
-
-  private static String DEFAULT_BUCKET_NAME = "shopizer";
-  private static String DEFAULT_REGION_NAME = "us-east-1";
-  private static final String ROOT_NAME = "files";
   private static S3StaticContentAssetsManagerImpl fileManager = null;
 
   private CMSManager cmsManager;
@@ -66,27 +54,18 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
   }
 
   @Override
-  public OutputContentFile getFile(String merchantStoreCode, FileContentType fileContentType,
-      String contentName) throws ServiceException {
+  public OutputContentFile getFile(String merchantStoreCode, FileContentType fileContentType, String contentName)
+      throws ServiceException {
     try {
       // get buckets
       String bucketName = bucketName();
 
-
       final AmazonS3 s3 = s3Client();
 
-      S3Object o =
-          s3.getObject(bucketName, nodePath(merchantStoreCode, fileContentType) + contentName);
-      byte[] byteArray = IOUtils.toByteArray(o.getObjectContent());
-      ByteArrayOutputStream baos = new ByteArrayOutputStream(byteArray.length);
-      baos.write(byteArray, 0, byteArray.length);
-      OutputContentFile ct = new OutputContentFile();
-      ct.setFile(baos);
-
-
+      S3Object o = s3.getObject(bucketName, nodePath(merchantStoreCode, fileContentType) + contentName);
 
       LOGGER.info("Content getFile");
-      return ct;
+      return getOutputContentFile(IOUtils.toByteArray(o.getObjectContent()));
     } catch (final Exception e) {
       LOGGER.error("Error while getting file", e);
       throw new ServiceException(e);
@@ -95,14 +74,13 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
   }
 
   @Override
-  public List<String> getFileNames(String merchantStoreCode, FileContentType fileContentType)
-      throws ServiceException {
+  public List<String> getFileNames(String merchantStoreCode, FileContentType fileContentType) throws ServiceException {
     try {
       // get buckets
       String bucketName = bucketName();
 
-      ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request()
-          .withBucketName(bucketName).withPrefix(nodePath(merchantStoreCode, fileContentType));
+      ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request().withBucketName(bucketName)
+          .withPrefix(nodePath(merchantStoreCode, fileContentType));
 
       List<String> fileNames = null;
 
@@ -122,7 +100,6 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
         }
       }
 
-
       LOGGER.info("Content get file names");
       return fileNames;
     } catch (final Exception e) {
@@ -139,10 +116,8 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
       // get buckets
       String bucketName = bucketName();
 
-
-
-      ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request()
-          .withBucketName(bucketName).withPrefix(nodePath(merchantStoreCode, fileContentType));
+      ListObjectsV2Request listObjectsRequest = new ListObjectsV2Request().withBucketName(bucketName)
+          .withPrefix(nodePath(merchantStoreCode, fileContentType));
 
       List<OutputContentFile> files = null;
       final AmazonS3 s3 = s3Client();
@@ -164,7 +139,6 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
         }
       }
 
-
       LOGGER.info("Content getFiles");
       return files;
     } catch (final Exception e) {
@@ -175,8 +149,7 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
   }
 
   @Override
-  public void addFile(String merchantStoreCode, InputContentFile inputStaticContentData)
-      throws ServiceException {
+  public void addFile(String merchantStoreCode, InputContentFile inputStaticContentData) throws ServiceException {
 
     try {
       // get buckets
@@ -186,16 +159,13 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
 
       final AmazonS3 s3 = s3Client();
 
-
       ObjectMetadata metadata = new ObjectMetadata();
       metadata.setContentType(inputStaticContentData.getMimeType());
-      PutObjectRequest request =
-          new PutObjectRequest(bucketName, nodePath + inputStaticContentData.getFileName(),
-              inputStaticContentData.getFile(), metadata);
+      PutObjectRequest request = new PutObjectRequest(bucketName, nodePath + inputStaticContentData.getFileName(),
+          inputStaticContentData.getFile(), metadata);
       request.setCannedAcl(CannedAccessControlList.PublicRead);
 
       s3.putObject(request);
-
 
       LOGGER.info("Content add file");
     } catch (final Exception e) {
@@ -203,8 +173,6 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
       throw new ServiceException(e);
 
     }
-
-
 
   }
 
@@ -219,13 +187,11 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
 
     }
 
-
   }
 
   @Override
-  public void removeFile(String merchantStoreCode, FileContentType staticContentType,
-      String fileName) throws ServiceException {
-
+  public void removeFile(String merchantStoreCode, FileContentType staticContentType, String fileName)
+      throws ServiceException {
 
     try {
       // get buckets
@@ -240,7 +206,6 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
       throw new ServiceException(e);
 
     }
-
 
   }
 
@@ -260,7 +225,6 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
       throw new ServiceException(e);
 
     }
-
 
   }
 
@@ -306,36 +270,11 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
     String region = regionName();
     LOGGER.debug("AWS CMS Using region " + region);
     AmazonS3 s3 = AmazonS3ClientBuilder.standard().withRegion(region) // The first region to
-                                                                            // try your request
-                                                                            // against
+                                                                      // try your request
+                                                                      // against
         .build();
 
     return s3;
-  }
-
-  private String bucketName() {
-    String bucketName = getCmsManager().getRootName();
-    if (StringUtils.isBlank(bucketName)) {
-      bucketName = DEFAULT_BUCKET_NAME;
-    }
-    return bucketName;
-  }
-
-  public static String getName(String filename) {
-    if (filename == null) {
-      return null;
-    }
-    int index = indexOfLastSeparator(filename);
-    return filename.substring(index + 1);
-  }
-
-  public static int indexOfLastSeparator(String filename) {
-    if (filename == null) {
-      return -1;
-    }
-    int lastUnixPos = filename.lastIndexOf(UNIX_SEPARATOR);
-    int lastWindowsPos = filename.lastIndexOf(WINDOWS_SEPARATOR);
-    return Math.max(lastUnixPos, lastWindowsPos);
   }
 
   private String regionName() {
@@ -345,39 +284,6 @@ public class S3StaticContentAssetsManagerImpl implements ContentAssetsManager {
     }
     return regionName;
   }
-
-  @SuppressWarnings("static-access")
-  private String nodePath(String store, FileContentType type) {
-
-    StringBuilder builder = new StringBuilder();
-    String root = nodePath(store);
-    builder.append(root);
-    if (type != null && !type.IMAGE.name().equals(type.name())
-        && !type.STATIC_FILE.name().equals(type.name())) {
-      builder.append(type.name()).append(Constants.SLASH);
-    }
-
-    return builder.toString();
-
-  }
-
-  private String nodePath(String store) {
-
-    StringBuilder builder = new StringBuilder();
-    builder.append(ROOT_NAME).append(Constants.SLASH).append(store).append(Constants.SLASH);
-    return builder.toString();
-
-  }
-
-  private boolean isInsideSubFolder(String key) {
-    int c = StringUtils.countMatches(key, Constants.SLASH);
-    if (c > 2) {
-      return true;
-    }
-
-    return false;
-  }
-
 
   public CMSManager getCmsManager() {
     return cmsManager;

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/gcp/GCPDownloadsManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/gcp/GCPDownloadsManagerImpl.java
@@ -1,0 +1,9 @@
+package com.salesmanager.core.business.modules.cms.content.gcp;
+
+import org.springframework.stereotype.Component;
+
+@Component("gcpDownloadsManager")
+public class GCPDownloadsManagerImpl extends GCPStaticContentAssetsManagerImpl {
+    private static final long serialVersionUID = 1L;
+  
+}

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/gcp/GCPStaticContentAssetsManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/gcp/GCPStaticContentAssetsManagerImpl.java
@@ -1,17 +1,31 @@
 package com.salesmanager.core.business.modules.cms.content.gcp;
 
+import java.io.IOException;
+import java.net.URLConnection;
+import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.Blob.BlobSourceOption;
+import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.Storage.BucketGetOption;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.content.ContentAssetsManager;
+import com.salesmanager.core.business.modules.cms.impl.CMSManager;
 import com.salesmanager.core.model.content.FileContentType;
 import com.salesmanager.core.model.content.InputContentFile;
 import com.salesmanager.core.model.content.OutputContentFile;
@@ -21,9 +35,7 @@ import com.salesmanager.core.model.content.OutputContentFile;
  * Cloud Storage with buckets
  * 
  * 
- * Linux/ Mac
- * export GOOGLE_APPLICATION_CREDENTIALS="/path/to/file"
- * For Windows
+ * Linux/ Mac export GOOGLE_APPLICATION_CREDENTIALS="/path/to/file" For Windows
  * set GOOGLE_APPLICATION_CREDENTIALS="C:\path\to\file"
  * 
  * following this article: https://www.baeldung.com/java-google-cloud-storage
@@ -37,74 +49,158 @@ import com.salesmanager.core.model.content.OutputContentFile;
 @Component("gcpContentAssetsManager")
 public class GCPStaticContentAssetsManagerImpl implements ContentAssetsManager {
 
-  /**
-   * 
-   */
   private static final long serialVersionUID = 1L;
-  
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(GCPStaticContentAssetsManagerImpl.class);
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(GCPStaticContentAssetsManagerImpl.class);
+
+  @Autowired
+  @Qualifier("gcpAssetsManager")
+  private CMSManager cmsManager;
 
   @Override
-  public OutputContentFile getFile(String merchantStoreCode, FileContentType fileContentType,
-      String contentName) throws ServiceException {
-    // TODO Auto-generated method stub
-    return null;
+  public OutputContentFile getFile(String merchantStoreCode, FileContentType fileContentType, String contentName)
+      throws ServiceException {
+    try {
+      String bucketName = bucketName();
+      // Instantiates a client
+      Storage storage = StorageOptions.getDefaultInstance().getService();
+
+      Blob blob = storage.get(BlobId.of(bucketName, nodePath(merchantStoreCode, fileContentType) + contentName));
+      LOGGER.info("Content getFile");
+
+      return getOutputContentFile(blob.getContent(BlobSourceOption.generationMatch()));
+
+    } catch (Exception e) {
+      LOGGER.error("Error while getting file", e);
+      throw new ServiceException(e);
+    }
   }
 
   @Override
-  public List<String> getFileNames(String merchantStoreCode, FileContentType fileContentType)
-      throws ServiceException {
-    // TODO Auto-generated method stub
-    return null;
+  public List<String> getFileNames(String merchantStoreCode, FileContentType fileContentType) throws ServiceException {
+    try {
+      String bucketName = bucketName();
+      Storage storage = StorageOptions.getDefaultInstance().getService();
+      long bucketMetaGeneration = 42;
+      Bucket bucket = storage.get(bucketName, BucketGetOption.metagenerationMatch(bucketMetaGeneration));
+      Page<Blob> blobs = bucket.list(Storage.BlobListOption.prefix(nodePath(merchantStoreCode, fileContentType)),
+          Storage.BlobListOption.fields(BlobField.NAME));
+
+      List<String> fileNames = new ArrayList<String>();
+
+      for (Blob blob : blobs.iterateAll()) {
+        if (isInsideSubFolder(blob.getName()))
+          continue;
+        String mimetype = URLConnection.guessContentTypeFromName(blob.getName());
+        if (!StringUtils.isBlank(mimetype)) {
+          fileNames.add(getName(blob.getName()));
+        }
+
+      }
+
+      LOGGER.info("Content get file names");
+      return fileNames;
+    } catch (Exception e) {
+      LOGGER.error("Error while getting file names", e);
+      throw new ServiceException(e);
+    }
   }
 
   @Override
   public List<OutputContentFile> getFiles(String merchantStoreCode, FileContentType fileContentType)
       throws ServiceException {
-    // TODO Auto-generated method stub
-    return null;
+    try {
+
+      List<String> fileNames = getFileNames(merchantStoreCode, fileContentType);
+      List<OutputContentFile> files = new ArrayList<OutputContentFile>();
+
+      for (String fileName : fileNames) {
+        files.add(getFile(merchantStoreCode, fileContentType, fileName));
+      }
+
+      LOGGER.info("Content get file names");
+      return files;
+    } catch (Exception e) {
+      LOGGER.error("Error while getting file names", e);
+      throw new ServiceException(e);
+    }
   }
 
   @Override
-  public void addFile(String merchantStoreCode, InputContentFile inputStaticContentData)
-      throws ServiceException {
-  
-    LOGGER.debug("Adding file " + inputStaticContentData.getFileName());
-    Storage storage = StorageOptions.getDefaultInstance().getService();
-    BlobId blobId = BlobId.of("bucket", "blob_name");
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
-    Blob blob = storage.create(blobInfo, /**image**/ null);
+  public void addFile(String merchantStoreCode, InputContentFile inputStaticContentData) throws ServiceException {
 
+    try {
+      LOGGER.debug("Adding file " + inputStaticContentData.getFileName());
+      String bucketName = bucketName();
+
+      String nodePath = nodePath(merchantStoreCode, inputStaticContentData.getFileContentType());
+
+      Storage storage = StorageOptions.getDefaultInstance().getService();
+
+      BlobId blobId = BlobId.of(bucketName, nodePath + inputStaticContentData.getFileName());
+      BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType(inputStaticContentData.getFileContentType().name())
+          .build();
+      byte[] targetArray = new byte[inputStaticContentData.getFile().available()];
+      inputStaticContentData.getFile().read(targetArray);
+      storage.create(blobInfo, targetArray);
+      LOGGER.info("Content add file");
+    } catch (IOException e) {
+      LOGGER.error("Error while adding file", e);
+      throw new ServiceException(e);
+    }
   }
 
   @Override
   public void addFiles(String merchantStoreCode, List<InputContentFile> inputStaticContentDataList)
       throws ServiceException {
-    // TODO Auto-generated method stub
+    if (CollectionUtils.isNotEmpty(inputStaticContentDataList)) {
+      for (InputContentFile inputFile : inputStaticContentDataList) {
+        this.addFile(merchantStoreCode, inputFile);
+      }
+    }
 
   }
 
   @Override
-  public void removeFile(String merchantStoreCode, FileContentType staticContentType,
-      String fileName) throws ServiceException {
-    // TODO Auto-generated method stub
+  public void removeFile(String merchantStoreCode, FileContentType staticContentType, String fileName)
+      throws ServiceException {
+    try {
+      String bucketName = bucketName();
+      Storage storage = StorageOptions.getDefaultInstance().getService();
+      storage.delete(bucketName, nodePath(merchantStoreCode, staticContentType) + fileName);
+
+      LOGGER.info("Remove file");
+    } catch (final Exception e) {
+      LOGGER.error("Error while removing file", e);
+      throw new ServiceException(e);
+    }
 
   }
 
   @Override
   public void removeFiles(String merchantStoreCode) throws ServiceException {
-    // TODO Auto-generated method stub
+    try {
+      // get buckets
+      String bucketName = bucketName();
+
+      Storage storage = StorageOptions.getDefaultInstance().getService();
+      storage.delete(bucketName, nodePath(merchantStoreCode));
+
+      LOGGER.info("Remove folder");
+    } catch (final Exception e) {
+      LOGGER.error("Error while removing folder", e);
+      throw new ServiceException(e);
+
+    }
 
   }
-  
-  private Bucket getBucket() {
-    
-    //Bucket bucket = storage.create(BucketInfo.of("shopizer-content")); //get bucket 
-    return null;
-    
-    
+
+  public CMSManager getCmsManager() {
+    return cmsManager;
+  }
+
+  public void setCmsManager(CMSManager cmsManager) {
+    this.cmsManager = cmsManager;
   }
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/infinispan/CmsStaticContentFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/infinispan/CmsStaticContentFileManagerImpl.java
@@ -432,5 +432,10 @@ public class CmsStaticContentFileManagerImpl
     return rootName;
   }
 
+  @Override
+  public CMSManager getCmsManager() {
+    return null;
+  }
+
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/local/CmsStaticContentFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/local/CmsStaticContentFileManagerImpl.java
@@ -417,6 +417,10 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
     this.cacheManager = cacheManager;
   }
 
+  @Override
+  public CMSManager getCmsManager() {
+    return null;
+  }
 
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/gcp/GCPProductContentFileManager.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/gcp/GCPProductContentFileManager.java
@@ -25,6 +25,8 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.BucketField;
+import com.google.cloud.storage.Storage.BucketGetOption;
 import com.google.cloud.storage.StorageOptions;
 import com.salesmanager.core.business.constants.Constants;
 import com.salesmanager.core.business.exception.ServiceException;
@@ -43,7 +45,7 @@ public class GCPProductContentFileManager implements ProductAssetsManager {
   @Autowired 
   private CMSManager gcpAssetsManager;
   
-  private static String DEFAULT_BUCKET_NAME = "shopizer-products-";
+  private static String DEFAULT_BUCKET_NAME = "shopizer";
   
   private static final Logger LOGGER = LoggerFactory.getLogger(GCPProductContentFileManager.class);
 
@@ -273,7 +275,7 @@ public class GCPProductContentFileManager implements ProductAssetsManager {
   }
   
   private boolean bucketExists(Storage storage, String bucketName) {
-    Bucket bucket = storage.get(bucketName);
+    Bucket bucket = storage.get(bucketName, BucketGetOption.fields(BucketField.NAME));
     if (bucket == null || !bucket.exists()) {
       return false;
     }

--- a/sm-core/src/main/resources/spring/shopizer-core-cms.xml
+++ b/sm-core/src/main/resources/spring/shopizer-core-cms.xml
@@ -62,13 +62,13 @@
 	<!-- Product downloads -->
 	<beans:bean id="productDownloadsFileManager" class="com.salesmanager.core.business.modules.cms.content.StaticContentFileManagerImpl">
 		<beans:property name="uploadFile">
-				<beans:ref bean="defaultDownloadsManager" />
+				<beans:ref bean="${config.cms.method}DownloadsManager" />
 		</beans:property>
 		<beans:property name="getFile">
-			<beans:ref bean="defaultDownloadsManager" />
+			<beans:ref bean="${config.cms.method}DownloadsManager" />
 		</beans:property>
 		<beans:property name="removeFile">
-			<beans:ref bean="defaultDownloadsManager" />
+			<beans:ref bean="${config.cms.method}DownloadsManager" />
 		</beans:property>
 	</beans:bean>
 	


### PR DESCRIPTION
I moved code from _StaticContentFileManagerImpl.java_ to the interface _ContentAssetsManager.java_ as default methods

_sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/StaticContentFileManagerImpl.java_
I defined  CMSManager getCmsManager(); in the interface, to be able to get the root name.

But I haved to implement it in this three managers. 
_sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/local/CmsStaticContentFileManagerImpl.java
sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/infinispan/CmsStaticContentFileManagerImpl.java
sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/StaticContentFileManagerImpl.java_


created new beans for each _DownloadsManagerImplementation_, I am not sure but _DownloadsManager_ is for electronic assets to sell, and doing this make them publicly available. may be we could protect them with a password in the bucket folder and then only shopizer can retrieve them and stream them to the user, once purchased.
sm-core/src/main/resources/spring/shopizer-core-cms.xml
sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/gcp/GCPDownloadsManagerImpl.java

I only tested this for GCP.