### PR TITLE
Fixed problem of uploading images via Image API

### DIFF
--- a/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/product/ProductImageApi.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/product/ProductImageApi.java
@@ -62,7 +62,7 @@ public class ProductImageApi {
   })
   public void uploadImages(
       @PathVariable Long id,
-      @RequestParam(value="file[]",required = true) MultipartFile[] files,
+      @RequestParam(value="file",required = true) MultipartFile[] files,
       @ApiIgnore MerchantStore merchantStore,
       @ApiIgnore Language language) {
 


### PR DESCRIPTION
Now we can add as many file(s) to upload image to product. Before, attaching Image to product was not happening. With this change, you can add Images to any Product on the fly. Refer to the attached Postman image to know about it

![Files issue](https://user-images.githubusercontent.com/20376377/95153427-0906fe80-0755-11eb-9f17-0f7795f2a590.png)

