### PR TITLE
Fixes query for product relationship delete

### DIFF
--- a/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/relationship/ProductRelationshipRepositoryImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/relationship/ProductRelationshipRepositoryImpl.java
@@ -266,7 +266,7 @@ public class ProductRelationshipRepositoryImpl implements ProductRelationshipRep
 	public List<ProductRelationship> listByProducts(Product product) {
 
 		StringBuilder qs = new StringBuilder();
-		qs.append("select pr from ProductRelationship as pr ");
+		qs.append("select distinct pr from ProductRelationship as pr ");
 		qs.append("left join fetch pr.product p ");
 		qs.append("left join fetch pr.relatedProduct rp ");
 		qs.append("left join fetch rp.attributes pattr ");


### PR DESCRIPTION
Steps to reproduce: 
1. Start with demo database
2. From admin Product list, try to delete product id: 1 (SKU: NK071)

Same `ProductRelationship` (id:3) comes duplicated. 