### PR TITLE
Adds locale based bigdecimal parser

### DIFF
--- a/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/shipping/CustomShippingMethodsController.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/shipping/CustomShippingMethodsController.java
@@ -19,6 +19,7 @@ import com.salesmanager.shop.admin.controller.ControllerConstants;
 import com.salesmanager.shop.admin.model.web.Menu;
 import com.salesmanager.shop.constants.Constants;
 import com.salesmanager.shop.utils.LabelUtils;
+import com.salesmanager.shop.utils.MerchantUtils;
 import org.apache.commons.beanutils.BeanComparator;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -564,7 +565,7 @@ public class CustomShippingMethodsController {
 		List<CustomShippingQuotesRegion> regions = customConfiguration.getRegions();
 		
 		try {
-			BigDecimal price = new BigDecimal(customQuote.getPriceText());
+			BigDecimal price = MerchantUtils.getBigDecimal(customQuote.getPriceText());
 			customQuote.setPrice(price);
 		} catch(Exception e) {
 			ObjectError error = new ObjectError("priceText",messages.getMessage("message.invalid.price", locale));

--- a/sm-shop/src/main/java/com/salesmanager/shop/utils/MerchantUtils.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/utils/MerchantUtils.java
@@ -1,6 +1,11 @@
 package com.salesmanager.shop.utils;
 
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.Date;
+import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -23,4 +28,19 @@ public class MerchantUtils {
 		return null;
 	}
 
+	/**
+	 * Locale based bigdecimal parser
+	 * @return
+	 */
+	public static BigDecimal getBigDecimal(String bigDecimal) throws ParseException {
+		NumberFormat decimalFormat = NumberFormat.getInstance(Locale.getDefault());
+		BigDecimal value;
+		if(decimalFormat instanceof DecimalFormat) {
+			((DecimalFormat) decimalFormat).setParseBigDecimal(true);
+			value = (BigDecimal) decimalFormat.parse(bigDecimal);
+		} else {
+			value = new BigDecimal(bigDecimal);
+		}
+		return value;
+	}
 }


### PR DESCRIPTION
In shipping configuration, when adding a custom weight based price, an error was showed when using a locale because `BigDecimal` parser was not taking configured `Locale`. 
This PR allows prices in localized formats. 