### PR TITLE
search for default Language in DB, instead creating a new Object without ID

### DIFF
--- a/sm-core/src/main/java/com/salesmanager/core/business/services/reference/language/LanguageServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/reference/language/LanguageServiceImpl.java
@@ -72,17 +72,12 @@ public class LanguageServiceImpl extends SalesManagerEntityServiceImpl<Integer, 
 	
 	@Override
 	public Language toLanguage(Locale locale) {
-		Language language = null;
 		try {
-			language = getLanguagesMap().get(locale.getLanguage());
-		} catch (Exception e) {
-			LOGGER.error("Cannot convert locale " + locale.getLanguage() + " to language");
-		}
-		if(language == null) {
-			language = new Language(Constants.DEFAULT_LANGUAGE);
-		}
-		return language;
-
+            return getLanguagesMap().containsKey(locale.getLanguage()) ? getLanguagesMap().get(locale.getLanguage()) : getByCode(Constants.DEFAULT_LANGUAGE.toString());
+            } catch (Exception e) {
+                LOGGER.error("Cannot find DB entry for default language: " + Constants.DEFAULT_LANGUAGE.toString());
+                return null;
+            }
 	}
 	
 	@Override


### PR DESCRIPTION
**Problem:**
If language mapping does not include the locale language, we shouldn't create a new Language object for the default language, as this object does not include the language ID(We are searching in admin/store for countries by language ID "not" set in this code. This Constructor should only be used in the DB initialization. 

**Solution:** 
Instead creating a Language object with constructor, we have to read the DB entry by code.