### PR TITLE
Updates to compile with spring-boot-starter-parent 2.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.6.RELEASE</version>
+		<version>2.5.4</version>
 	</parent>
 
 	<modules>

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductServiceImpl.java
@@ -128,10 +128,6 @@ public class ProductServiceImpl extends SalesManagerEntityServiceImpl<Long, Prod
 		return productRepository.getProductsListByIds(idSet);
 	}
 
-	public Product getById(Long productId) {
-		return productRepository.getById(productId);
-	}
-
 	@Override
 	public Product getProductWithOnlyMerchantStoreById(Long productId) {
 		return productRepository.getProductWithOnlyMerchantStoreById(productId);


### PR DESCRIPTION
Just updated version of spring-boot-starter-parent and removed one method
public Product getById(Long productId)
ProductServiceImpl

Recompiled all. Tested manually by creating and completing 2 orders.