### PR TITLE
admin - fix IllegalStateException when calling editStore without mand…

### DIFF
--- a/sm-shop/pom.xml
+++ b/sm-shop/pom.xml
@@ -169,6 +169,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-rng-simple -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/ControllerConstants.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/ControllerConstants.java
@@ -65,6 +65,7 @@ public interface ControllerConstants
         
         interface Store{
             final String stores="admin-stores";
+            final String store="admin-store";
         }
 
 

--- a/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/merchant/MerchantStoreController.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/admin/controller/merchant/MerchantStoreController.java
@@ -28,6 +28,7 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -175,7 +176,7 @@ public class MerchantStoreController {
 
 	@PreAuthorize("hasRole('STORE')")
 	@RequestMapping(value = "/admin/store/editStore.html", method = RequestMethod.GET)
-	public String displayMerchantStore(@ModelAttribute("id") Integer id, Model model, HttpServletRequest request,
+	public String displayMerchantStore(@RequestParam("id") Integer id, Model model, HttpServletRequest request,
 			HttpServletResponse response, Locale locale) throws Exception {
 
 		setMenu(model, request);
@@ -226,7 +227,7 @@ public class MerchantStoreController {
 		model.addAttribute("sizes", sizes);
 		model.addAttribute("store", store);
 
-		return "admin-store";
+		return ControllerConstants.Tiles.Store.store;
 
 	}
 

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/merchant/MerchantStoreIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/merchant/MerchantStoreIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.salesmanager.test.shop.integration.admin.merchant;
+
+import com.salesmanager.core.business.services.merchant.MerchantStoreService;
+import com.salesmanager.core.model.merchant.MerchantStore;
+import com.salesmanager.shop.admin.controller.ControllerConstants;
+import com.salesmanager.shop.application.ShopApplication;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * Contains tests targeting {@link com.salesmanager.shop.admin.controller.merchant.MerchantStoreController}
+ */
+@SpringBootTest(classes = ShopApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@RunWith(SpringRunner.class)
+public class MerchantStoreIntegrationTest {
+    private static final String QUERY_PARAM_ID = "id";
+
+    private MockMvc mvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    /**
+     * used to retrieve an existing merchant store
+     */
+    @Autowired
+    private MerchantStoreService merchantService;
+
+    @Before
+    public void setup() {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+    }
+
+    @Test
+    @WithMockUser(roles = {"STORE"})
+    public void editStoreInformsAboutMissingID() throws Exception {
+        // when endpoint is called without any store ID
+        ResultActions resultActions = callEditStoreEndpoint(null);
+
+        // then a message indicating that the required request parameter is missing
+        String expectedErrorSubString = String.format("Required request parameter '%s'", QUERY_PARAM_ID);
+        resultActions.andExpect(model().attribute("errMsg", containsString(expectedErrorSubString)));
+    }
+
+    @Test
+    @WithMockUser(roles = {"STORE"})
+    public void callEditStoreWithExistingID() throws Exception {
+        // when endpoint is called with an existing store ID
+        Integer existingID = merchantService.getByCode(MerchantStore.DEFAULT_STORE).getId();
+        ResultActions resultActions = callEditStoreEndpoint(existingID.toString());
+
+        // then the correct view is expected without any error
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(view().name(ControllerConstants.Tiles.Store.store))
+                .andExpect(model().hasNoErrors())
+                .andExpect(model().attributeExists("store"));
+    }
+
+    private ResultActions callEditStoreEndpoint(String queryParam) throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = get("/admin/store/editStore.html");
+        if (queryParam != null) {
+            requestBuilder.queryParam(QUERY_PARAM_ID, queryParam);
+        }
+        return mvc.perform(requestBuilder);
+    }
+}


### PR DESCRIPTION
admin - fix IllegalStateException when calling editStore without mandatory 'id' parameter
    
    @ModelAttribute for parameter types not having a default constructor is always dirty from technical perspective,
    since Spring tries to create that property type in case the corresponding parameter is not provided.
    
    Besides that, the "id" model attribute is never consumed.
    
    Basically, the endpoint just wants to say, that the id parameter is mandatory, so it should result in an appropriate error.

closes #643