### PR TITLE
remove 'webEnvironment' from MockMvc-based tests

### DIFF
--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/merchant/MerchantStoreIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/merchant/MerchantStoreIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Contains tests targeting {@link com.salesmanager.shop.admin.controller.merchant.MerchantStoreController}
  */
-@SpringBootTest(classes = ShopApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = ShopApplication.class)
 @RunWith(SpringRunner.class)
 public class MerchantStoreIntegrationTest {
     private static final String QUERY_PARAM_ID = "id";

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/products/ProductKeywordsIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/products/ProductKeywordsIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Contains tests targeting {@link com.salesmanager.shop.admin.controller.products.ProductKeywordsController}
  */
-@SpringBootTest(classes = ShopApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = ShopApplication.class)
 @RunWith(SpringRunner.class)
 public class ProductKeywordsIntegrationTest {
 

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/user/UsersIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/admin/user/UsersIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Contains tests targeting {@link com.salesmanager.shop.admin.controller.user.UserController}
  */
-@SpringBootTest(classes = ShopApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = ShopApplication.class)
 @RunWith(SpringRunner.class)
 public class UsersIntegrationTest {
 


### PR DESCRIPTION
remove 'webEnvironment' from MockMvc-based tests

When using MockMvc, the default webEnvironment 'MOCK' is perfectly fine