### PR TITLE
Upgrade Jackson version used.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<postgresql.version>42.2.18</postgresql.version>
 		<simple-json-version>1.1.1</simple-json-version>
 		<jackson-version-databind>2.12.6.1</jackson-version-databind>
-		<jackson-version>2.10.2</jackson-version>
+		<jackson-version>2.14.0</jackson-version>
 		<geoip2.version>2.7.0</geoip2.version>
 		<drools.version>7.32.0.Final</drools.version>
 		<google-client-maps-services-version>0.1.6</google-client-maps-services-version>


### PR DESCRIPTION
Apparently 2.10.2 does not include com.fasterxml.jackson.core.util.JacksonFeature, which is required by jackson-databind. This change upgrades jackson to the latest version (2.14.2).

Fixes #843.