### PR TITLE
Update pom for jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
 		<oracle.version>18.3.0.0</oracle.version>
 		<postgresql.version>42.2.18</postgresql.version>
 		<simple-json-version>1.1.1</simple-json-version>
-		<jackson-version-databind>2.10.2</jackson-version-databind>
-		<jackson-version>2.10.2</jackson-version>
+		<jackson-version-databind>2.13.4.1</jackson-version-databind>
+		<jackson-version>2.13.4</jackson-version>
 		<geoip2.version>2.7.0</geoip2.version>
 		<drools.version>7.32.0.Final</drools.version>
 		<google-client-maps-services-version>0.1.6</google-client-maps-services-version>


### PR DESCRIPTION
During the command mvnw clean install an error caused by Jackson version mismatch occurred. THis commit resolves the error.