### PR TITLE
existsBySku query in ProductRepository fixed

### DIFF
--- a/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepository.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepository.java
@@ -10,11 +10,14 @@ import com.salesmanager.core.model.catalog.product.Product;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
-	
-	@Query(value="select case when count(p)> 0 then true else false end"
-			+ " from Product p join p.merchantStore pm"
-			+ " left join p.Variants pinst "
-			+ " where pinst.sku=?1 or p.sku=?1 and pm.id=?2",nativeQuery = true)
+
+	@Query(value="SELECT " +
+			"CASE WHEN COUNT(*) > 0 THEN true ELSE false END " +
+			"FROM " +
+			"Product p " +
+			"JOIN MerchantStore m ON m.id = ?2 " +
+			"LEFT JOIN ProductVariant pv ON pv.product.id = p.id " +
+			"WHERE (pv.sku = ?1 OR p.sku = ?1)")
 	boolean existsBySku(String sku, Integer store);
 	
 	@Query(


### PR DESCRIPTION
While creating product (via admin panel ) and adding unique identifier field It returned an error:

{
    "errorCode": "500",
    "message": "could not extract ResultSet; SQL [n/a]; nested exception is org.hibernate.exception.SQLGrammarException: could not extract ResultSet, You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'where pinst.sku='1' or p.sku='1' and pm.id=1' at line 1"
}

![image](https://user-images.githubusercontent.com/25928579/221582440-c7069f51-18bd-4046-a1e7-2f067c68a0b9.png)


I rewrote query so it is now working. Also tested.