### PR TITLE
Refactor model entities to use Lombok; add constants package

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.11-tem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,12 @@
 			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+   			<groupId>org.projectlombok</groupId>
+  			<artifactId>lombok</artifactId>
+    		<version>1.18.38</version>
+		</dependency>
 
 	</dependencies>
 

--- a/sm-core-model/pom.xml
+++ b/sm-core-model/pom.xml
@@ -119,6 +119,13 @@
 			<artifactId>commons-fileupload</artifactId>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+   			<groupId>org.projectlombok</groupId>
+  			<artifactId>lombok</artifactId>
+    		<version>1.18.38</version>
+		</dependency>
+
 	</dependencies>
 
 		<build>

--- a/sm-core-model/src/main/java/com/salesmanager/core/model/system/credentials/Credentials.java
+++ b/sm-core-model/src/main/java/com/salesmanager/core/model/system/credentials/Credentials.java
@@ -1,20 +1,14 @@
 package com.salesmanager.core.model.system.credentials;
 
-public abstract class Credentials {
-	
-	private String userName;
-	private String password;
-	public String getUserName() {
-		return userName;
-	}
-	public void setUserName(String userName) {
-		this.userName = userName;
-	}
-	public String getPassword() {
-		return password;
-	}
-	public void setPassword(String password) {
-		this.password = password;
-	}
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
+@Getter
+@Setter
+@ToString(exclude = "password") // prevents password from leaking in logs
+public abstract class Credentials {
+    
+    private String userName;
+    private String password;
 }

--- a/sm-core-model/src/main/java/com/salesmanager/core/model/system/credentials/DbCredentials.java
+++ b/sm-core-model/src/main/java/com/salesmanager/core/model/system/credentials/DbCredentials.java
@@ -1,5 +1,8 @@
 package com.salesmanager.core.model.system.credentials;
 
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
 public class DbCredentials extends Credentials {
 
 }

--- a/sm-core/pom.xml
+++ b/sm-core/pom.xml
@@ -238,6 +238,12 @@
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+   			<groupId>org.projectlombok</groupId>
+  			<artifactId>lombok</artifactId>
+    		<version>1.18.38</version>
+		</dependency>
 
 	</dependencies>
 	

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/db/DbConfig.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/db/DbConfig.java
@@ -1,13 +1,16 @@
 package com.salesmanager.core.business.configuration.db;
-
-import javax.inject.Inject;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import com.salesmanager.core.model.system.credentials.DbCredentials;
 
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
 public class DbConfig {
 	
-    @Inject Environment env;
+    private final Environment env;
 
     @Bean
     public DbCredentials dbCredentials() {

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductAttributeEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductAttributeEvent.java
@@ -3,19 +3,16 @@ package com.salesmanager.core.business.configuration.events.products;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.attribute.ProductAttribute;
 
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true, exclude = "productAttribute")
 public class DeleteProductAttributeEvent extends ProductEvent {
-	
-	
-	private static final long serialVersionUID = 1L;
 	private ProductAttribute productAttribute;
 
 	public DeleteProductAttributeEvent(Object source, ProductAttribute productAttribute, Product product) {
 		super(source, product);
 		this.productAttribute=productAttribute;
 	}
-
-	public ProductAttribute getProductAttribute() {
-		return productAttribute;
-	}
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductEvent.java
@@ -4,8 +4,6 @@ import com.salesmanager.core.model.catalog.product.Product;
 
 public class DeleteProductEvent extends ProductEvent {
 
-	private static final long serialVersionUID = 1L;
-
 	public DeleteProductEvent(Object source, Product product) {
 		super(source, product);
 	}

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductImageEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductImageEvent.java
@@ -3,21 +3,16 @@ package com.salesmanager.core.business.configuration.events.products;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.image.ProductImage;
 
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true, exclude = "productImage")
 public class DeleteProductImageEvent extends ProductEvent {
-	
-	
-	private static final long serialVersionUID = 1L;
 	private ProductImage productImage;
-
-	public ProductImage getProductImage() {
-		return productImage;
-	}
-
 	public DeleteProductImageEvent(Object source, ProductImage productImage, Product product) {
 		super(source, product);
 		this.productImage = productImage;
 
 	}
-
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductVariantEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/DeleteProductVariantEvent.java
@@ -3,18 +3,16 @@ package com.salesmanager.core.business.configuration.events.products;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.variant.ProductVariant;
 
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true, exclude = "variant")
 public class DeleteProductVariantEvent extends ProductEvent {
-	
-	private static final long serialVersionUID = 1L;
 	private ProductVariant variant;
 
 	public DeleteProductVariantEvent(Object source, ProductVariant variant, Product product) {
 		super(source, product);
 		this.variant = variant;
 	}
-
-	public ProductVariant getVariant() {
-		return variant;
-	}
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/ProductAttributeEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/ProductAttributeEvent.java
@@ -3,9 +3,6 @@ package com.salesmanager.core.business.configuration.events.products;
 import com.salesmanager.core.model.catalog.product.Product;
 
 public class ProductAttributeEvent extends ProductEvent {
-
-	private static final long serialVersionUID = 1L;
-
 	public ProductAttributeEvent(Object source, Product product) {
 		super(source, product);
 	}

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/ProductEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/ProductEvent.java
@@ -4,19 +4,14 @@ import org.springframework.context.ApplicationEvent;
 
 import com.salesmanager.core.model.catalog.product.Product;
 
+import lombok.Getter;
+
+@Getter
 public abstract class ProductEvent extends ApplicationEvent {
-	
-	private static final long serialVersionUID = 1L;
 	private Product product;
 	
 	public ProductEvent(Object source, Product product) {
 		super(source);
 		this.product = product;
 	}
-
-
-	public Product getProduct() {
-		return product;
-	}
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductAttributeEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductAttributeEvent.java
@@ -3,19 +3,15 @@ package com.salesmanager.core.business.configuration.events.products;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.attribute.ProductAttribute;
 
+import lombok.Getter;
+import lombok.ToString;
+@Getter
+@ToString(callSuper = true, exclude = "productAttribute")
 public class SaveProductAttributeEvent extends ProductEvent {
-	
-	
-	private static final long serialVersionUID = 1L;
 	private ProductAttribute productAttribute;
 
 	public SaveProductAttributeEvent(Object source, ProductAttribute productAttribute, Product product) {
 		super(source, product);
 		this.productAttribute=productAttribute;
 	}
-
-	public ProductAttribute getProductAttribute() {
-		return productAttribute;
-	}
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductEvent.java
@@ -7,10 +7,4 @@ public class SaveProductEvent extends ProductEvent {
 	public SaveProductEvent(Object source, Product product) {
 		super(source, product);
 	}
-
-	private static final long serialVersionUID = 1L;
-	
-	
-	
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductImageEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductImageEvent.java
@@ -3,21 +3,15 @@ package com.salesmanager.core.business.configuration.events.products;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.image.ProductImage;
 
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true, exclude = "productImage")
 public class SaveProductImageEvent extends ProductEvent {
-	
-	
-	private static final long serialVersionUID = 1L;
 	private ProductImage productImage;
-
-	public ProductImage getProductImage() {
-		return productImage;
-	}
-
 	public SaveProductImageEvent(Object source, ProductImage productImage, Product product) {
 		super(source, product);
 		this.productImage = productImage;
-
 	}
-
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductVariantEvent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/configuration/events/products/SaveProductVariantEvent.java
@@ -3,19 +3,16 @@ package com.salesmanager.core.business.configuration.events.products;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.variant.ProductVariant;
 
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true, exclude = "variant")
 public class SaveProductVariantEvent extends ProductEvent {
-	
-	private static final long serialVersionUID = 1L;
 	private ProductVariant variant;
 
 	public SaveProductVariantEvent(Object source, ProductVariant variant, Product product) {
 		super(source, product);
 		this.variant = variant;
 	}
-
-	public ProductVariant getVariant() {
-		return variant;
-	}
-
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/constants/Constants.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/constants/Constants.java
@@ -49,5 +49,7 @@ public class Constants {
   public final static Currency DEFAULT_CURRENCY = Currency.getInstance(Locale.US);
   
   public final static String PAYMENT_MODULES = "PAYMENT";
+  public final static String TEMPLATE_PATH = "templates/email";
+  public static final String CHARSET = "UTF-8";
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/constants/CoreBusinessConstants.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/constants/CoreBusinessConstants.java
@@ -11,7 +11,7 @@ import java.util.Locale;
  * @author carlsamson
  *
  */
-public class Constants {
+public class CoreBusinessConstants {
 
   public static final Charset ISO_8859_1 = StandardCharsets.ISO_8859_1;
   public static final Charset UTF_8 = StandardCharsets.UTF_8;
@@ -51,5 +51,13 @@ public class Constants {
   public final static String PAYMENT_MODULES = "PAYMENT";
   public final static String TEMPLATE_PATH = "templates/email";
   public static final String CHARSET = "UTF-8";
+  public static final String HOST = "host"; 
+  public static final String PORT = "port";
+  public static final String PROTOCOL = "protocol";
+  public static final String USERNAME = "username";
+  public static final String PASSWORD = "password";
+  public static final String SMTP_AUTH = "smtpAuth";
+  public static final String STARTTLS = "starttls";
+  public static final String EMAIL_TEMPLATES_PATH = "emailTemplatesPath";
 
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/constants/SerializationConstants.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/constants/SerializationConstants.java
@@ -1,0 +1,10 @@
+package com.salesmanager.core.business.constants;
+
+public final class SerializationConstants {
+
+    private SerializationConstants() {
+        // prevent instantiation
+    }
+
+    public static final long EMAIL_SERIAL_VERSION_UID = 6481794982612826257L;
+}

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/ContentAssetsManager.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/ContentAssetsManager.java
@@ -2,7 +2,7 @@ package com.salesmanager.core.business.modules.cms.content;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.modules.cms.common.AssetsManager;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
 import com.salesmanager.core.model.content.FileContentType;
@@ -33,7 +33,7 @@ public interface ContentAssetsManager extends AssetsManager, FileGet, FilePut, F
         String root = nodePath(store);
         builder.append(root);
         if (type != null && !FileContentType.IMAGE.name().equals(type.name()) && !FileContentType.STATIC_FILE.name().equals(type.name())) {
-            builder.append(type.name()).append(Constants.SLASH);
+            builder.append(type.name()).append(CoreBusinessConstants.SLASH);
         }
 
         return builder.toString();
@@ -43,7 +43,7 @@ public interface ContentAssetsManager extends AssetsManager, FileGet, FilePut, F
     default String nodePath(String store) {
 
         StringBuilder builder = new StringBuilder();
-        builder.append(ROOT_NAME).append(Constants.SLASH).append(store).append(Constants.SLASH);
+        builder.append(ROOT_NAME).append(CoreBusinessConstants.SLASH).append(store).append(CoreBusinessConstants.SLASH);
         return builder.toString();
 
     }
@@ -57,7 +57,7 @@ public interface ContentAssetsManager extends AssetsManager, FileGet, FilePut, F
     }
 
     default boolean isInsideSubFolder(String key) {
-        int c = StringUtils.countMatches(key, Constants.SLASH);
+        int c = StringUtils.countMatches(key, CoreBusinessConstants.SLASH);
         return c > 2;
     }
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/infinispan/CmsStaticContentFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/infinispan/CmsStaticContentFileManagerImpl.java
@@ -20,7 +20,7 @@ import org.infinispan.tree.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.content.ContentAssetsManager;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
@@ -432,7 +432,7 @@ public class CmsStaticContentFileManagerImpl
 		String nodePath = this.getNodePath(merchantStoreCode, FileContentType.IMAGE);
 		
 		StringBuilder appender = new StringBuilder();
-		appender.append(nodePath).append(Constants.SLASH);
+		appender.append(nodePath).append(CoreBusinessConstants.SLASH);
 
 		path.ifPresent(appender::append);
 		
@@ -450,7 +450,7 @@ public class CmsStaticContentFileManagerImpl
 
 		}
 		
-		appender.append(Constants.SLASH).append(folderName);
+		appender.append(CoreBusinessConstants.SLASH).append(folderName);
 		
 		Fqn newFolderFqn = Fqn.fromString(appender.toString());
 		cacheManager.getTreeCache().getRoot().addChild(newFolderFqn);

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/local/CmsStaticContentFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/content/local/CmsStaticContentFileManagerImpl.java
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.content.ContentAssetsManager;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
@@ -117,8 +117,8 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 			this.createDirectoryIfNorExist(merchantPath);
 
 			// file path
-			nodePath.append(Constants.SLASH).append(inputStaticContentData.getFileContentType())
-					.append(Constants.SLASH);
+			nodePath.append(CoreBusinessConstants.SLASH).append(inputStaticContentData.getFileContentType())
+					.append(CoreBusinessConstants.SLASH);
 			Path dirPath = Paths.get(nodePath.toString());
 			this.createDirectoryIfNorExist(dirPath);
 
@@ -202,13 +202,13 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 			for (final InputContentFile inputStaticContentData : inputStaticContentDataList) {
 
 				// file path
-				nodePath.append(Constants.SLASH).append(inputStaticContentData.getFileContentType())
-						.append(Constants.SLASH);
+				nodePath.append(CoreBusinessConstants.SLASH).append(inputStaticContentData.getFileContentType())
+						.append(CoreBusinessConstants.SLASH);
 				Path dirPath = Paths.get(nodePath.toString());
 				this.createDirectoryIfNorExist(dirPath);
 
 				// file creation
-				nodePath.append(Constants.SLASH).append(inputStaticContentData.getFileName());
+				nodePath.append(CoreBusinessConstants.SLASH).append(inputStaticContentData.getFileName());
 
 				Path path = Paths.get(nodePath.toString());
 
@@ -270,8 +270,8 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 		try {
 
 			StringBuilder merchantPath = new StringBuilder();
-			merchantPath.append(buildRootPath()).append(Constants.SLASH).append(merchantStoreCode)
-					.append(Constants.SLASH).append(staticContentType).append(Constants.SLASH).append(fileName);
+			merchantPath.append(buildRootPath()).append(CoreBusinessConstants.SLASH).append(merchantStoreCode)
+					.append(CoreBusinessConstants.SLASH).append(staticContentType).append(CoreBusinessConstants.SLASH).append(fileName);
 
 			Path path = Paths.get(merchantPath.toString());
 
@@ -295,7 +295,7 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 		try {
 
 			StringBuilder merchantPath = new StringBuilder();
-			merchantPath.append(buildRootPath()).append(Constants.SLASH).append(merchantStoreCode);
+			merchantPath.append(buildRootPath()).append(CoreBusinessConstants.SLASH).append(merchantStoreCode);
 
 			Path path = Paths.get(merchantPath.toString());
 
@@ -323,7 +323,7 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 		try {
 
 			StringBuilder merchantPath = new StringBuilder();
-			merchantPath.append(buildRootPath()).append(merchantStoreCode).append(Constants.SLASH)
+			merchantPath.append(buildRootPath()).append(merchantStoreCode).append(CoreBusinessConstants.SLASH)
 					.append(staticContentType);
 
 			Path path = Paths.get(merchantPath.toString());
@@ -376,8 +376,8 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 	}
 
 	private String buildRootPath() {
-		return new StringBuilder().append(getRootName()).append(Constants.SLASH).append(ROOT_CONTAINER)
-				.append(Constants.SLASH).toString();
+		return new StringBuilder().append(getRootName()).append(CoreBusinessConstants.SLASH).append(ROOT_CONTAINER)
+				.append(CoreBusinessConstants.SLASH).toString();
 
 	}
 
@@ -409,7 +409,7 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 			if(folderPath.isPresent()) {
 				nodePath
 				.append(merchantPath.toString())
-				.append(Constants.SLASH).append(folderPath.get()).append(Constants.SLASH);
+				.append(CoreBusinessConstants.SLASH).append(folderPath.get()).append(CoreBusinessConstants.SLASH);
 			}
 			// add folder
 			nodePath.append(folderName);
@@ -450,9 +450,9 @@ public class CmsStaticContentFileManagerImpl implements ContentAssetsManager {
 			
 			Path merchantPath = this.buildMerchantPath(merchantStoreCode);
 			StringBuilder nodePath = new StringBuilder();
-			nodePath.append(merchantPath.toString()).append(Constants.SLASH);
+			nodePath.append(merchantPath.toString()).append(CoreBusinessConstants.SLASH);
 			if(folderPath.isPresent()) {
-				nodePath.append(folderPath.get()).append(Constants.SLASH);
+				nodePath.append(folderPath.get()).append(CoreBusinessConstants.SLASH);
 			}
 			
 			nodePath.append(folderName);

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/ProductFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/ProductFileManagerImpl.java
@@ -13,7 +13,7 @@ import javax.imageio.ImageIO;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.utils.CoreConfiguration;
 import com.salesmanager.core.business.utils.ProductImageCropUtils;
@@ -166,7 +166,7 @@ public class ProductFileManagerImpl extends ProductFileManager {
         }
 
         if (!StringUtils.isBlank(configuration.getProperty(CROP_UPLOADED_IMAGES))
-            && configuration.getProperty(CROP_UPLOADED_IMAGES).equals(Constants.TRUE)) {
+            && configuration.getProperty(CROP_UPLOADED_IMAGES).equals(CoreBusinessConstants.TRUE)) {
           // crop image
           ProductImageCropUtils utils =
               new ProductImageCropUtils(bufferedImage, largeImageWidth, largeImageHeight);

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/aws/S3ProductContentFileManager.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/aws/S3ProductContentFileManager.java
@@ -19,7 +19,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
 import com.salesmanager.core.business.modules.cms.product.ProductAssetsManager;
@@ -295,8 +295,8 @@ public class S3ProductContentFileManager
   }
 
   private String nodePath(String store) {
-    return new StringBuilder().append(ROOT_NAME).append(Constants.SLASH).append(store)
-        .append(Constants.SLASH).toString();
+    return new StringBuilder().append(ROOT_NAME).append(CoreBusinessConstants.SLASH).append(store)
+        .append(CoreBusinessConstants.SLASH).toString();
   }
 
   private String nodePath(String store, String product) {
@@ -307,7 +307,7 @@ public class S3ProductContentFileManager
     sb.append(nodePath);
 
     // product path
-    sb.append(product).append(Constants.SLASH);
+    sb.append(product).append(CoreBusinessConstants.SLASH);
     return sb.toString();
 
   }
@@ -326,7 +326,7 @@ public class S3ProductContentFileManager
       sb.append(LARGE);
     }
 
-    return sb.append(Constants.SLASH).toString();
+    return sb.append(CoreBusinessConstants.SLASH).toString();
 
 
   }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/gcp/GCPProductContentFileManager.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/gcp/GCPProductContentFileManager.java
@@ -30,7 +30,7 @@ import com.google.cloud.storage.Storage.BlobListOption;
 import com.google.cloud.storage.Storage.BucketField;
 import com.google.cloud.storage.Storage.BucketGetOption;
 import com.google.cloud.storage.StorageOptions;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
 import com.salesmanager.core.business.modules.cms.product.ProductAssetsManager;
@@ -290,9 +290,9 @@ public class GCPProductContentFileManager implements ProductAssetsManager {
   
   private String filePath(String merchant, String sku, FileContentType contentImage) {
       StringBuilder sb = new StringBuilder();
-      sb.append("products").append(Constants.SLASH);
+      sb.append("products").append(CoreBusinessConstants.SLASH);
       sb.append(merchant)
-      .append(Constants.SLASH).append(sku).append(Constants.SLASH);
+      .append(CoreBusinessConstants.SLASH).append(sku).append(CoreBusinessConstants.SLASH);
 
       // small large
       if (contentImage.name().equals(FileContentType.PRODUCT.name())) {
@@ -301,18 +301,18 @@ public class GCPProductContentFileManager implements ProductAssetsManager {
         sb.append(LARGE);
       }
 
-      return sb.append(Constants.SLASH).toString();
+      return sb.append(CoreBusinessConstants.SLASH).toString();
     
   }
   
   private String filePath(String merchant, String sku, String size, String fileName) {
     StringBuilder sb = new StringBuilder();
-    sb.append("products").append(Constants.SLASH);
+    sb.append("products").append(CoreBusinessConstants.SLASH);
     sb.append(merchant)
-    .append(Constants.SLASH).append(sku).append(Constants.SLASH);
+    .append(CoreBusinessConstants.SLASH).append(sku).append(CoreBusinessConstants.SLASH);
     
     sb.append(size);
-    sb.append(Constants.SLASH).append(fileName);
+    sb.append(CoreBusinessConstants.SLASH).append(fileName);
 
     return sb.toString();
   

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/infinispan/CmsImageFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/infinispan/CmsImageFileManagerImpl.java
@@ -15,7 +15,7 @@ import org.infinispan.tree.Fqn;
 import org.infinispan.tree.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
 import com.salesmanager.core.business.modules.cms.impl.CacheManager;
@@ -112,8 +112,8 @@ public class CmsImageFileManagerImpl implements ProductAssetsManager {
       // node
       StringBuilder nodePath = new StringBuilder();
       nodePath.append(productImage.getProduct().getMerchantStore().getCode())
-          .append(Constants.SLASH).append(productImage.getProduct().getSku())
-          .append(Constants.SLASH);
+          .append(CoreBusinessConstants.SLASH).append(productImage.getProduct().getSku())
+          .append(CoreBusinessConstants.SLASH);
 
 
       if (contentImage.getFileContentType().name().equals(FileContentType.PRODUCT.name())) {
@@ -260,7 +260,7 @@ public class CmsImageFileManagerImpl implements ProductAssetsManager {
 
       StringBuilder nodePath = new StringBuilder();
       nodePath.append(productImage.getProduct().getMerchantStore().getCode())
-          .append(Constants.SLASH).append(productImage.getProduct().getSku());
+          .append(CoreBusinessConstants.SLASH).append(productImage.getProduct().getSku());
 
 
       Node<String, Object> productNode = this.getNode(nodePath.toString());
@@ -393,8 +393,8 @@ public class CmsImageFileManagerImpl implements ProductAssetsManager {
 
       // SMALL by default
       StringBuilder nodePath = new StringBuilder();
-      nodePath.append(merchantStoreCode).append(Constants.SLASH).append(productCode)
-          .append(Constants.SLASH).append(size);
+      nodePath.append(merchantStoreCode).append(CoreBusinessConstants.SLASH).append(productCode)
+          .append(CoreBusinessConstants.SLASH).append(size);
 
       Node<String, Object> productNode = this.getNode(nodePath.toString());
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/local/CmsImageFileManagerImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/cms/product/local/CmsImageFileManagerImpl.java
@@ -10,7 +10,7 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.cms.impl.CMSManager;
 import com.salesmanager.core.business.modules.cms.impl.LocalCacheManagerImpl;
@@ -98,8 +98,8 @@ public class CmsImageFileManagerImpl
       this.createDirectoryIfNorExist(merchantPath);
 
       // product path
-      nodePath.append(Constants.SLASH).append(productImage.getProduct().getSku())
-          .append(Constants.SLASH);
+      nodePath.append(CoreBusinessConstants.SLASH).append(productImage.getProduct().getSku())
+          .append(CoreBusinessConstants.SLASH);
       Path dirPath = Paths.get(nodePath.toString());
       this.createDirectoryIfNorExist(dirPath);
 
@@ -115,7 +115,7 @@ public class CmsImageFileManagerImpl
 
 
       // file creation
-      nodePath.append(Constants.SLASH).append(contentImage.getFileName());
+      nodePath.append(CoreBusinessConstants.SLASH).append(contentImage.getFileName());
 
 
       Path path = Paths.get(nodePath.toString());
@@ -167,7 +167,7 @@ public class CmsImageFileManagerImpl
 
 
       StringBuilder merchantPath = new StringBuilder();
-      merchantPath.append(buildRootPath()).append(Constants.SLASH).append(merchantStoreCode);
+      merchantPath.append(buildRootPath()).append(CoreBusinessConstants.SLASH).append(merchantStoreCode);
 
       Path path = Paths.get(merchantPath.toString());
 
@@ -190,13 +190,13 @@ public class CmsImageFileManagerImpl
 
 
       StringBuilder nodePath = new StringBuilder();
-      nodePath.append(buildRootPath()).append(Constants.SLASH)
-          .append(productImage.getProduct().getMerchantStore().getCode()).append(Constants.SLASH)
+      nodePath.append(buildRootPath()).append(CoreBusinessConstants.SLASH)
+          .append(productImage.getProduct().getMerchantStore().getCode()).append(CoreBusinessConstants.SLASH)
           .append(productImage.getProduct().getSku());
 
       // delete small
       StringBuilder smallPath = new StringBuilder(nodePath);
-      smallPath.append(Constants.SLASH).append(SMALL).append(Constants.SLASH)
+      smallPath.append(CoreBusinessConstants.SLASH).append(SMALL).append(CoreBusinessConstants.SLASH)
           .append(productImage.getProductImage());
 
 
@@ -206,7 +206,7 @@ public class CmsImageFileManagerImpl
 
       // delete large
       StringBuilder largePath = new StringBuilder(nodePath);
-      largePath.append(Constants.SLASH).append(LARGE).append(Constants.SLASH)
+      largePath.append(CoreBusinessConstants.SLASH).append(LARGE).append(CoreBusinessConstants.SLASH)
           .append(productImage.getProductImage());
 
 
@@ -228,8 +228,8 @@ public class CmsImageFileManagerImpl
 
 
       StringBuilder nodePath = new StringBuilder();
-      nodePath.append(buildRootPath()).append(Constants.SLASH)
-          .append(product.getMerchantStore().getCode()).append(Constants.SLASH)
+      nodePath.append(buildRootPath()).append(CoreBusinessConstants.SLASH)
+          .append(product.getMerchantStore().getCode()).append(CoreBusinessConstants.SLASH)
           .append(product.getSku());
 
 
@@ -275,8 +275,8 @@ public class CmsImageFileManagerImpl
 
 
   private String buildRootPath() {
-    return new StringBuilder().append(getRootName()).append(Constants.SLASH).append(ROOT_CONTAINER)
-        .append(Constants.SLASH).toString();
+    return new StringBuilder().append(getRootName()).append(CoreBusinessConstants.SLASH).append(ROOT_CONTAINER)
+        .append(CoreBusinessConstants.SLASH).toString();
 
   }
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/email/DefaultEmailSenderImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/email/DefaultEmailSenderImpl.java
@@ -22,7 +22,7 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -83,7 +83,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
         BodyPart textPart = new MimeBodyPart();
         freemarkerMailConfiguration.setClassForTemplateLoading(DefaultEmailSenderImpl.class, "/");
         Template textTemplate = freemarkerMailConfiguration.getTemplate(
-            new StringBuilder(Constants.TEMPLATE_PATH).append("/").append(tmpl).toString());
+            new StringBuilder(CoreBusinessConstants.TEMPLATE_PATH).append("/").append(tmpl).toString());
         final StringWriter textWriter = new StringWriter();
         try {
           textTemplate.process(templateTokens, textWriter);
@@ -94,7 +94,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
           public InputStream getInputStream() throws IOException {
             // return new StringBufferInputStream(textWriter
             // .toString());
-            return new ByteArrayInputStream(textWriter.toString().getBytes(Constants.CHARSET));
+            return new ByteArrayInputStream(textWriter.toString().getBytes(CoreBusinessConstants.CHARSET));
           }
 
           public OutputStream getOutputStream() throws IOException {
@@ -116,7 +116,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
         BodyPart htmlPage = new MimeBodyPart();
         freemarkerMailConfiguration.setClassForTemplateLoading(DefaultEmailSenderImpl.class, "/");
         Template htmlTemplate = freemarkerMailConfiguration.getTemplate(
-            new StringBuilder(Constants.TEMPLATE_PATH).append("/").append(tmpl).toString());
+            new StringBuilder(CoreBusinessConstants.TEMPLATE_PATH).append("/").append(tmpl).toString());
         final StringWriter htmlWriter = new StringWriter();
         try {
           htmlTemplate.process(templateTokens, htmlWriter);
@@ -127,7 +127,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
           public InputStream getInputStream() throws IOException {
             // return new StringBufferInputStream(htmlWriter
             // .toString());
-            return new ByteArrayInputStream(textWriter.toString().getBytes(Constants.CHARSET));
+            return new ByteArrayInputStream(textWriter.toString().getBytes(CoreBusinessConstants.CHARSET));
           }
 
           public OutputStream getOutputStream() throws IOException {

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/email/DefaultEmailSenderImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/email/DefaultEmailSenderImpl.java
@@ -21,6 +21,9 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.stereotype.Component;
+
+import com.salesmanager.core.business.constants.Constants;
+
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -34,10 +37,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
   @Inject
   private JavaMailSender mailSender;
 
-  private static final String CHARSET = "UTF-8";
   private EmailConfig emailConfig;
-
-  private final static String TEMPLATE_PATH = "templates/email";
 
   @Override
   public void send(Email email) throws Exception {
@@ -62,8 +62,8 @@ public class DefaultEmailSenderImpl implements EmailModule {
           impl.setPassword(emailConfig.getPassword());
 
           Properties prop = new Properties();
-          prop.put("mail.smtp.auth", emailConfig.isSmtpAuth());
-          prop.put("mail.smtp.starttls.enable", emailConfig.isStarttls());
+          prop.put("mail.smtp.auth", String.valueOf(emailConfig.isSmtpAuth()));
+          prop.put("mail.smtp.starttls.enable", String.valueOf(emailConfig.isStarttls()));
           impl.setJavaMailProperties(prop);
         }
 
@@ -83,7 +83,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
         BodyPart textPart = new MimeBodyPart();
         freemarkerMailConfiguration.setClassForTemplateLoading(DefaultEmailSenderImpl.class, "/");
         Template textTemplate = freemarkerMailConfiguration.getTemplate(
-            new StringBuilder(TEMPLATE_PATH).append("/").append(tmpl).toString());
+            new StringBuilder(Constants.TEMPLATE_PATH).append("/").append(tmpl).toString());
         final StringWriter textWriter = new StringWriter();
         try {
           textTemplate.process(templateTokens, textWriter);
@@ -94,7 +94,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
           public InputStream getInputStream() throws IOException {
             // return new StringBufferInputStream(textWriter
             // .toString());
-            return new ByteArrayInputStream(textWriter.toString().getBytes(CHARSET));
+            return new ByteArrayInputStream(textWriter.toString().getBytes(Constants.CHARSET));
           }
 
           public OutputStream getOutputStream() throws IOException {
@@ -116,7 +116,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
         BodyPart htmlPage = new MimeBodyPart();
         freemarkerMailConfiguration.setClassForTemplateLoading(DefaultEmailSenderImpl.class, "/");
         Template htmlTemplate = freemarkerMailConfiguration.getTemplate(
-            new StringBuilder(TEMPLATE_PATH).append("/").append(tmpl).toString());
+            new StringBuilder(Constants.TEMPLATE_PATH).append("/").append(tmpl).toString());
         final StringWriter htmlWriter = new StringWriter();
         try {
           htmlTemplate.process(templateTokens, htmlWriter);
@@ -127,7 +127,7 @@ public class DefaultEmailSenderImpl implements EmailModule {
           public InputStream getInputStream() throws IOException {
             // return new StringBufferInputStream(htmlWriter
             // .toString());
-            return new ByteArrayInputStream(textWriter.toString().getBytes(CHARSET));
+            return new ByteArrayInputStream(textWriter.toString().getBytes(Constants.CHARSET));
           }
 
           public OutputStream getOutputStream() throws IOException {

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/email/Email.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/email/Email.java
@@ -4,67 +4,26 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.salesmanager.core.business.constants.SerializationConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Email implements Serializable {
-	
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 6481794982612826257L;
-	private String from;
-	private String fromEmail;
-	private String to;
-	private String subject;
-	private String templateName;
-	
-	private Map<String,String> templateTokens = new HashMap<String,String>();
 
-	public String getFrom() {
-		return from;
-	}
+   private static final long serialVersionUID = SerializationConstants.EMAIL_SERIAL_VERSION_UID;
+    private String from;
+    private String fromEmail;
+    private String to;
+    private String subject;
+    private String templateName;
 
-	public void setFrom(String from) {
-		this.from = from;
-	}
-
-	public String getTo() {
-		return to;
-	}
-
-	public void setTo(String to) {
-		this.to = to;
-	}
-
-	public String getSubject() {
-		return subject;
-	}
-
-	public void setSubject(String subject) {
-		this.subject = subject;
-	}
-
-	public String getTemplateName() {
-		return templateName;
-	}
-
-	public void setTemplateName(String templateName) {
-		this.templateName = templateName;
-	}
-
-	public Map<String, String> getTemplateTokens() {
-		return templateTokens;
-	}
-
-	public void setTemplateTokens(Map<String, String> templateTokens) {
-		this.templateTokens = templateTokens;
-	}
-
-	public void setFromEmail(String fromEmail) {
-		this.fromEmail = fromEmail;
-	}
-
-	public String getFromEmail() {
-		return fromEmail;
-	}
-
+    @Builder.Default
+    private Map<String, String> templateTokens = new HashMap<>();
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/email/EmailComponent.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/email/EmailComponent.java
@@ -4,50 +4,43 @@ import javax.inject.Inject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+
 @Component("htmlEmailSender")
+@RequiredArgsConstructor
 public class EmailComponent implements HtmlEmailSender {
-  
-  @Value("${config.emailSender}")
-  private String emailSender;
 
-  @Inject
-  private EmailModule defaultEmailSender;
+    @Value("${config.emailSender}")
+    private String emailSender;
 
-  @Inject
-  private EmailModule sesEmailSender;
+    private final EmailModule defaultEmailSender;
+    private final EmailModule sesEmailSender;
 
-  @Override
-  public void send(Email email) throws Exception {
-    switch(emailSender) 
-    { 
-        case "default": 
-          defaultEmailSender.send(email);
-            break; 
-        case "ses": 
-          sesEmailSender.send(email);
-            break; 
-        default: 
-            throw new Exception("No email implementation for " + emailSender); 
+    @Override
+    public void send(Email email) throws Exception {
+        switch (emailSender) {
+            case "default":
+                defaultEmailSender.send(email);
+                break;
+            case "ses":
+                sesEmailSender.send(email);
+                break;
+            default:
+                throw new Exception("No email implementation for " + emailSender);
+        }
     }
-    
-  }
 
-  @Override
-  public void setEmailConfig(EmailConfig emailConfig) {
-    switch(emailSender) 
-    { 
-        case "default": 
-          defaultEmailSender.setEmailConfig(emailConfig);
-            break; 
-        case "ses": 
-          sesEmailSender.setEmailConfig(emailConfig);
-            break; 
-        default: 
- 
+    @Override
+    public void setEmailConfig(EmailConfig emailConfig) {
+        switch (emailSender) {
+            case "default":
+                defaultEmailSender.setEmailConfig(emailConfig);
+                break;
+            case "ses":
+                sesEmailSender.setEmailConfig(emailConfig);
+                break;
+            default:
+                // No-op for unknown configs
+        }
     }
-    
-  }
-
-
-
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/email/EmailConfig.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/email/EmailConfig.java
@@ -3,111 +3,39 @@ package com.salesmanager.core.business.modules.email;
 import org.json.simple.JSONAware;
 import org.json.simple.JSONObject;
 
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class EmailConfig implements JSONAware {
 
-	private String host;
-	private String port;
-	private String protocol;
-	private String username;
-	private String password;
-	private boolean smtpAuth = false;
-	private boolean starttls = false;
-	
-	private String emailTemplatesPath = null;
-	
-	@SuppressWarnings("unchecked")
-	@Override
-	public String toJSONString() {
-		JSONObject data = new JSONObject();
-		data.put("host", this.getHost());
-		data.put("port", this.getPort());
-		data.put("protocol", this.getProtocol());
-		data.put("username", this.getUsername());
-		data.put("smtpAuth", this.isSmtpAuth());
-		data.put("starttls", this.isStarttls());
-		data.put("password", this.getPassword());
-		return data.toJSONString();
-	}
-	
-	
+    private String host;
+    private String port;
+    private String protocol;
+    private String username;
+    private String password;
+    private boolean smtpAuth = false;
+    private boolean starttls = false;
+    private String emailTemplatesPath;
 
-	public boolean isSmtpAuth() {
-		return smtpAuth;
-	}
-	public void setSmtpAuth(boolean smtpAuth) {
-		this.smtpAuth = smtpAuth;
-	}
-	public boolean isStarttls() {
-		return starttls;
-	}
-	public void setStarttls(boolean starttls) {
-		this.starttls = starttls;
-	}
-	public void setEmailTemplatesPath(String emailTemplatesPath) {
-		this.emailTemplatesPath = emailTemplatesPath;
-	}
-	public String getEmailTemplatesPath() {
-		return emailTemplatesPath;
-	}
-
-
-
-	public String getHost() {
-		return host;
-	}
-
-
-
-	public void setHost(String host) {
-		this.host = host;
-	}
-
-
-
-	public String getPort() {
-		return port;
-	}
-
-
-
-	public void setPort(String port) {
-		this.port = port;
-	}
-
-
-
-	public String getProtocol() {
-		return protocol;
-	}
-
-
-
-	public void setProtocol(String protocol) {
-		this.protocol = protocol;
-	}
-
-
-
-	public String getUsername() {
-		return username;
-	}
-
-
-
-	public void setUsername(String username) {
-		this.username = username;
-	}
-
-
-
-	public String getPassword() {
-		return password;
-	}
-
-
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
+    @Override
+    @SuppressWarnings("unchecked")
+    public String toJSONString() {
+        JSONObject data = new JSONObject();
+        data.put(CoreBusinessConstants.HOST, this.host);
+        data.put(CoreBusinessConstants.PORT, this.port);
+        data.put(CoreBusinessConstants.PROTOCOL, this.protocol);
+        data.put(CoreBusinessConstants.USERNAME, this.username);
+        data.put(CoreBusinessConstants.SMTP_AUTH, this.smtpAuth);
+        data.put(CoreBusinessConstants.STARTTLS, this.starttls);
+        data.put(CoreBusinessConstants.PASSWORD, this.password);
+        return data.toJSONString();
+    }
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/integration/payment/impl/PayPalExpressCheckoutPayment.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/integration/payment/impl/PayPalExpressCheckoutPayment.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
 import com.salesmanager.core.business.utils.CoreConfiguration;
@@ -190,7 +190,7 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 			BigDecimal tax = null;
 			for(OrderTotal total : orderTotals) {
 				
-				if(total.getModule().equals(Constants.OT_SHIPPING_MODULE_CODE)) {
+				if(total.getModule().equals(CoreBusinessConstants.OT_SHIPPING_MODULE_CODE)) {
 					BasicAmountType shipping = new BasicAmountType();
 					shipping.setCurrencyID(urn.ebay.apis.eBLBaseComponents.CurrencyCodeType.fromValue(store.getCurrency().getCode()));
 					shipping.setValue(pricingService.getStringAmount(total.getValue(), store));
@@ -198,7 +198,7 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 					paymentDetails.setShippingTotal(shipping);
 				}
 				
-				if(total.getModule().equals(Constants.OT_HANDLING_MODULE_CODE)) {
+				if(total.getModule().equals(CoreBusinessConstants.OT_HANDLING_MODULE_CODE)) {
 					BasicAmountType handling = new BasicAmountType();
 					handling.setCurrencyID(urn.ebay.apis.eBLBaseComponents.CurrencyCodeType.fromValue(store.getCurrency().getCode()));
 					handling.setValue(pricingService.getStringAmount(total.getValue(), store));
@@ -206,7 +206,7 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 					paymentDetails.setHandlingTotal(handling);
 				}
 				
-				if(total.getModule().equals(Constants.OT_TAX_MODULE_CODE)) {
+				if(total.getModule().equals(CoreBusinessConstants.OT_TAX_MODULE_CODE)) {
 					if(tax==null) {
 						tax = new BigDecimal("0");
 					}
@@ -252,16 +252,16 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 			RETURN_URL.append(
 					baseScheme);
 			
-			if(!StringUtils.isBlank(baseScheme) && !baseScheme.endsWith(Constants.SLASH)) {
-				RETURN_URL.append(Constants.SLASH);
+			if(!StringUtils.isBlank(baseScheme) && !baseScheme.endsWith(CoreBusinessConstants.SLASH)) {
+				RETURN_URL.append(CoreBusinessConstants.SLASH);
 			}
 			RETURN_URL.append(coreConfiguration.getProperty("CONTEXT_PATH", "sm-shop"));
 					
 
 
 			SetExpressCheckoutRequestDetailsType setExpressCheckoutRequestDetails = new SetExpressCheckoutRequestDetailsType();
-			String returnUrl = RETURN_URL.toString() + new StringBuilder().append(Constants.SHOP_URI).append("/paypal/checkout").append(coreConfiguration.getProperty("URL_EXTENSION", ".html")).append("/success").toString();
-			String cancelUrl = RETURN_URL.toString() + new StringBuilder().append(Constants.SHOP_URI).append("/paypal/checkout").append(coreConfiguration.getProperty("URL_EXTENSION", ".html")).append("/cancel").toString();
+			String returnUrl = RETURN_URL.toString() + new StringBuilder().append(CoreBusinessConstants.SHOP_URI).append("/paypal/checkout").append(coreConfiguration.getProperty("URL_EXTENSION", ".html")).append("/success").toString();
+			String cancelUrl = RETURN_URL.toString() + new StringBuilder().append(CoreBusinessConstants.SHOP_URI).append("/paypal/checkout").append(coreConfiguration.getProperty("URL_EXTENSION", ".html")).append("/cancel").toString();
 			
 			setExpressCheckoutRequestDetails.setReturnURL(returnUrl);
 			setExpressCheckoutRequestDetails.setCancelURL(cancelUrl);
@@ -278,7 +278,7 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 			
 			String mode = "sandbox";
 			String env = configuration.getEnvironment();
-			if(Constants.PRODUCTION_ENVIRONMENT.equals(env)) {
+			if(CoreBusinessConstants.PRODUCTION_ENVIRONMENT.equals(env)) {
 				mode = "production";
 			}
 
@@ -355,7 +355,7 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 			
 			String mode = "sandbox";
 			String env = configuration.getEnvironment();
-			if(Constants.PRODUCTION_ENVIRONMENT.equals(env)) {
+			if(CoreBusinessConstants.PRODUCTION_ENVIRONMENT.equals(env)) {
 				mode = "production";
 			}
 
@@ -444,7 +444,7 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 			
 			String mode = "sandbox";
 			String env = configuration.getEnvironment();
-			if(Constants.PRODUCTION_ENVIRONMENT.equals(env)) {
+			if(CoreBusinessConstants.PRODUCTION_ENVIRONMENT.equals(env)) {
 				mode = "production";
 			}
 			
@@ -575,7 +575,7 @@ public class PayPalExpressCheckoutPayment implements PaymentModule {
 			
 			String mode = "sandbox";
 			String env = configuration.getEnvironment();
-			if(Constants.PRODUCTION_ENVIRONMENT.equals(env)) {
+			if(CoreBusinessConstants.PRODUCTION_ENVIRONMENT.equals(env)) {
 				mode = "production";
 			}
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/integration/shipping/impl/USPSShippingQuote.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/integration/shipping/impl/USPSShippingQuote.java
@@ -27,7 +27,7 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.services.reference.country.CountryService;
 import com.salesmanager.core.business.utils.DataUtils;
 import com.salesmanager.core.business.utils.ProductPriceUtils;
@@ -273,7 +273,7 @@ public class USPSShippingQuote implements ShippingQuoteModule {
 			c.add(Calendar.DATE, 3);
 			Date newDate = c.getTime();
 			
-			SimpleDateFormat format = new SimpleDateFormat(Constants.DEFAULT_DATE_FORMAT);
+			SimpleDateFormat format = new SimpleDateFormat(CoreBusinessConstants.DEFAULT_DATE_FORMAT);
 			String shipDate = format.format(newDate);
 			
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/order/total/ManufacturerShippingCodeOrderTotalModuleImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/order/total/ManufacturerShippingCodeOrderTotalModuleImpl.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.price.FinalPrice;
@@ -88,9 +88,9 @@ public class ManufacturerShippingCodeOrderTotalModuleImpl implements OrderTotalP
 		OrderTotal orderTotal = null;
 		if(inputParameters.getDiscount() != null) {
 				orderTotal = new OrderTotal();
-				orderTotal.setOrderTotalCode(Constants.OT_DISCOUNT_TITLE);
+				orderTotal.setOrderTotalCode(CoreBusinessConstants.OT_DISCOUNT_TITLE);
 				orderTotal.setOrderTotalType(OrderTotalType.SUBTOTAL);
-				orderTotal.setTitle(Constants.OT_SUBTOTAL_MODULE_CODE);
+				orderTotal.setTitle(CoreBusinessConstants.OT_SUBTOTAL_MODULE_CODE);
 				
 				//calculate discount that will be added as a negative value
 				FinalPrice productPrice = pricingService.calculateProductPrice(product);

--- a/sm-core/src/main/java/com/salesmanager/core/business/modules/order/total/PromoCodeCalculatorModule.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/modules/order/total/PromoCodeCalculatorModule.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.salesmanager.core.business.configuration.DroolsBeanFactory;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.price.FinalPrice;
@@ -87,9 +87,9 @@ public class PromoCodeCalculatorModule implements OrderTotalPostProcessorModule 
 			OrderTotal orderTotal = null;
 			if(resp.getDiscount() != null) {
 					orderTotal = new OrderTotal();
-					orderTotal.setOrderTotalCode(Constants.OT_DISCOUNT_TITLE);
+					orderTotal.setOrderTotalCode(CoreBusinessConstants.OT_DISCOUNT_TITLE);
 					orderTotal.setOrderTotalType(OrderTotalType.SUBTOTAL);
-					orderTotal.setTitle(Constants.OT_SUBTOTAL_MODULE_CODE);
+					orderTotal.setTitle(CoreBusinessConstants.OT_SUBTOTAL_MODULE_CODE);
 					orderTotal.setText(summary.getPromoCode());
 					
 					//calculate discount that will be added as a negative value

--- a/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/repositories/catalog/product/ProductRepositoryImpl.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.utils.RepositoryHelper;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.ProductCriteria;
@@ -481,7 +481,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 			int first, int max) {
 
 		List regionList = new ArrayList();
-		regionList.add(Constants.ALL_REGIONS);
+		regionList.add(CoreBusinessConstants.ALL_REGIONS);
 		if (locale != null) {
 			regionList.add(locale.getCountry());
 		}

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/category/CategoryService.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/category/CategoryService.java
@@ -42,7 +42,7 @@ public interface CategoryService extends SalesManagerEntityService<Long, Categor
 	
 	Category getById(Long id, int merchantId);
 	
-	Category getById(Long categoryid, int merchantId, int language);
+	Category getById(Long categoryId, int merchantId, int language);
 	
 	Page<Category> getListByDepth(MerchantStore store, Language language, String name, int depth, int page, int count);
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/category/CategoryServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/category/CategoryServiceImpl.java
@@ -15,7 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.repositories.catalog.category.CategoryDescriptionRepository;
 import com.salesmanager.core.business.repositories.catalog.category.CategoryRepository;
@@ -232,7 +232,7 @@ public class CategoryServiceImpl extends SalesManagerEntityServiceImpl<Long, Cat
 
 		// get category with lineage (subcategories)
 		StringBuilder lineage = new StringBuilder();
-		lineage.append(category.getLineage()).append(category.getId()).append(Constants.SLASH);
+		lineage.append(category.getLineage()).append(category.getId()).append(CoreBusinessConstants.SLASH);
 		List<Category> categories = this.getListByLineage(category.getMerchantStore(), lineage.toString());
 
 		Category dbCategory = getById(category.getId(), category.getMerchantStore().getId());
@@ -322,8 +322,8 @@ public class CategoryServiceImpl extends SalesManagerEntityServiceImpl<Long, Cat
 
 				child.setParent(p);
 				child.setDepth(depth + 1);
-				child.setLineage(new StringBuilder().append(lineage).append(Constants.SLASH).append(child.getId())
-						.append(Constants.SLASH).toString());
+				child.setLineage(new StringBuilder().append(lineage).append(CoreBusinessConstants.SLASH).append(child.getId())
+						.append(CoreBusinessConstants.SLASH).toString());
 
 			}
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/inventory/ProductInventoryServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/inventory/ProductInventoryServiceImpl.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jsoup.helper.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import com.salesmanager.core.business.constants.CoreBusinessConstants;
@@ -19,6 +20,7 @@ import com.salesmanager.core.model.catalog.product.variant.ProductVariant;
 
 
 @Service("inventoryService")
+@Transactional
 public class ProductInventoryServiceImpl implements ProductInventoryService {
 	
 	

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/inventory/ProductInventoryServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/inventory/ProductInventoryServiceImpl.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
 import com.salesmanager.core.model.catalog.product.Product;
@@ -65,7 +65,7 @@ public class ProductInventoryServiceImpl implements ProductInventoryService {
 		
 		for (ProductAvailability availability : availabilities) {
 			if (!StringUtils.isEmpty(availability.getRegion())
-					&& availability.getRegion().equals(Constants.ALL_REGIONS)) {// TODO REL 2.1 accept a region
+					&& availability.getRegion().equals(CoreBusinessConstants.ALL_REGIONS)) {// TODO REL 2.1 accept a region
 				defaultAvailability = availability;
 			}
 		}

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/pricing/PricingServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/pricing/PricingServiceImpl.java
@@ -68,7 +68,8 @@ public class PricingServiceImpl implements PricingService {
 			return priceUtil.getStoreFormatedAmountWithCurrency(store,amount);
 		} catch (Exception e) {
 			LOGGER.error("An error occured when trying to format an amount " + amount.toString());
-			throw new ServiceException(e);
+			LOGGER.error("An error occured when trying to format an amount " +e.getMessage());
+			throw new ServiceException(e.getMessage());
 		}
 	}
 	

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductService.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/ProductService.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
 
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.common.generic.SalesManagerEntityService;
@@ -18,7 +19,7 @@ import com.salesmanager.core.model.reference.language.Language;
 import com.salesmanager.core.model.tax.taxclass.TaxClass;
 
 
-
+@Service
 public interface ProductService extends SalesManagerEntityService<Long, Product> {
 
 	Optional<Product> retrieveById(Long id, MerchantStore store);

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/manufacturer/ManufacturerServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/catalog/product/manufacturer/ManufacturerServiceImpl.java
@@ -1,6 +1,5 @@
 package com.salesmanager.core.business.services.catalog.product.manufacturer;
 
-
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.repositories.catalog.product.manufacturer.ManufacturerRepository;
 import com.salesmanager.core.business.repositories.catalog.product.manufacturer.PageableManufacturerRepository;
@@ -10,37 +9,31 @@ import com.salesmanager.core.model.catalog.product.manufacturer.Manufacturer;
 import com.salesmanager.core.model.catalog.product.manufacturer.ManufacturerDescription;
 import com.salesmanager.core.model.merchant.MerchantStore;
 import com.salesmanager.core.model.reference.language.Language;
+import lombok.extern.slf4j.Slf4j;
 import org.jsoup.helper.Validate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import javax.inject.Inject;
 import java.util.HashSet;
 import java.util.List;
 
-
-
 @Service("manufacturerService")
+@Slf4j
 public class ManufacturerServiceImpl extends SalesManagerEntityServiceImpl<Long, Manufacturer>
     implements ManufacturerService {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ManufacturerServiceImpl.class);
+  private final PageableManufacturerRepository pageableManufacturerRepository;
+  private final ManufacturerRepository manufacturerRepository;
 
-  @Inject
-  private PageableManufacturerRepository pageableManufacturerRepository;
-  
-  private ManufacturerRepository manufacturerRepository;
-
-  @Inject
-  public ManufacturerServiceImpl(ManufacturerRepository manufacturerRepository) {
-    super(manufacturerRepository);
+  public ManufacturerServiceImpl(
+      PageableManufacturerRepository pageableManufacturerRepository,
+      ManufacturerRepository manufacturerRepository) {
+    super(manufacturerRepository); 
+    this.pageableManufacturerRepository = pageableManufacturerRepository;
     this.manufacturerRepository = manufacturerRepository;
   }
-
   @Override
   public void delete(Manufacturer manufacturer) throws ServiceException {
     manufacturer = this.getById(manufacturer.getId());
@@ -50,9 +43,7 @@ public class ManufacturerServiceImpl extends SalesManagerEntityServiceImpl<Long,
   @Override
   public Long getCountManufAttachedProducts(Manufacturer manufacturer) throws ServiceException {
     return manufacturerRepository.countByProduct(manufacturer.getId());
-    // .getCountManufAttachedProducts( manufacturer );
   }
-
 
   @Override
   public List<Manufacturer> listByStore(MerchantStore store, Language language)
@@ -74,12 +65,9 @@ public class ManufacturerServiceImpl extends SalesManagerEntityServiceImpl<Long,
   @Override
   public void addManufacturerDescription(Manufacturer manufacturer,
       ManufacturerDescription description) throws ServiceException {
-
-
     if (manufacturer.getDescriptions() == null) {
-      manufacturer.setDescriptions(new HashSet<ManufacturerDescription>());
+      manufacturer.setDescriptions(new HashSet<>());
     }
-
     manufacturer.getDescriptions().add(description);
     description.setManufacturer(manufacturer);
     update(manufacturer);
@@ -87,24 +75,19 @@ public class ManufacturerServiceImpl extends SalesManagerEntityServiceImpl<Long,
 
   @Override
   public void saveOrUpdate(Manufacturer manufacturer) throws ServiceException {
-
-    LOGGER.debug("Creating Manufacturer");
-
+    log.debug("Saving manufacturer");
     if (manufacturer.getId() != null && manufacturer.getId() > 0) {
       super.update(manufacturer);
-
     } else {
       super.create(manufacturer);
-
     }
   }
 
   @Override
-  public Manufacturer getByCode(com.salesmanager.core.model.merchant.MerchantStore store,
-      String code) {
+  public Manufacturer getByCode(MerchantStore store, String code) {
     return manufacturerRepository.findByCodeAndMerchandStore(code, store.getId());
   }
-  
+
   @Override
   public Manufacturer getById(Long id) {
     return manufacturerRepository.findOne(id);
@@ -114,15 +97,15 @@ public class ManufacturerServiceImpl extends SalesManagerEntityServiceImpl<Long,
   public List<Manufacturer> listByProductsInCategory(MerchantStore store, Category category,
       Language language) throws ServiceException {
     Validate.notNull(store, "Store cannot be null");
-    Validate.notNull(category,"Category cannot be null");
+    Validate.notNull(category, "Category cannot be null");
     Validate.notNull(language, "Language cannot be null");
-    return manufacturerRepository.findByProductInCategoryId(store.getId(), category.getLineage(), language.getId());
+    return manufacturerRepository.findByProductInCategoryId(
+        store.getId(), category.getLineage(), language.getId());
   }
 
   @Override
   public Page<Manufacturer> listByStore(MerchantStore store, Language language, int page, int count)
       throws ServiceException {
-
     Pageable pageRequest = PageRequest.of(page, count);
     return pageableManufacturerRepository.findByStore(store.getId(), language.getId(), null, pageRequest);
   }
@@ -136,7 +119,6 @@ public class ManufacturerServiceImpl extends SalesManagerEntityServiceImpl<Long,
   @Override
   public Page<Manufacturer> listByStore(MerchantStore store, Language language, String name,
       int page, int count) throws ServiceException {
-
     Pageable pageRequest = PageRequest.of(page, count);
     return pageableManufacturerRepository.findByStore(store.getId(), language.getId(), name, pageRequest);
   }
@@ -144,7 +126,6 @@ public class ManufacturerServiceImpl extends SalesManagerEntityServiceImpl<Long,
   @Override
   public Page<Manufacturer> listByStore(MerchantStore store, String name, int page, int count)
       throws ServiceException {
-
     Pageable pageRequest = PageRequest.of(page, count);
     return pageableManufacturerRepository.findByStore(store.getId(), name, pageRequest);
   }

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/common/generic/SalesManagerEntityServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/common/generic/SalesManagerEntityServiceImpl.java
@@ -3,85 +3,60 @@ package com.salesmanager.core.business.services.common.generic;
 import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.model.generic.SalesManagerEntity;
+import lombok.RequiredArgsConstructor;
 
-/**
- * @param <T> entity type
- */
+@RequiredArgsConstructor
 public abstract class SalesManagerEntityServiceImpl<K extends Serializable & Comparable<K>, E extends SalesManagerEntity<K, ?>>
-	implements SalesManagerEntityService<K, E> {
-	
-	/**
-	 * Classe de l'entité, déterminé à partir des paramètres generics.
-	 */
-	private Class<E> objectClass;
+    implements SalesManagerEntityService<K, E> {
 
+  private final JpaRepository<E, K> repository;
+  private final Class<E> objectClass = (Class<E>) ((ParameterizedType) getClass()
+      .getGenericSuperclass()).getActualTypeArguments()[1];
 
-    private JpaRepository<E, K> repository;
+  protected final Class<E> getObjectClass() {
+    return objectClass;
+  }
 
-	@SuppressWarnings("unchecked")
-	public SalesManagerEntityServiceImpl(JpaRepository<E, K> repository) {
-		ParameterizedType genericSuperclass = (ParameterizedType) getClass().getGenericSuperclass();
-		this.objectClass = (Class<E>) genericSuperclass.getActualTypeArguments()[1];
-		this.repository = repository;
-	}
-	
-	protected final Class<E> getObjectClass() {
-		return objectClass;
-	}
+  public E getById(K id) {
+    return repository.getOne(id);
+  }
 
+  public void save(E entity) throws ServiceException {
+    repository.saveAndFlush(entity);
+  }
 
-	public E getById(K id) {
-		return repository.getOne(id);
-	}
+  public void saveAll(Iterable<E> entities) throws ServiceException {
+    repository.saveAll(entities);
+  }
 
-	
-	public void save(E entity) throws ServiceException {
-		repository.saveAndFlush(entity);
-	}
-	
-	public void saveAll(Iterable<E> entities) throws ServiceException {
-		repository.saveAll(entities);
-	}
-	
-	
-	public void create(E entity) throws ServiceException {
-		save(entity);
-	}
+  public void create(E entity) throws ServiceException {
+    save(entity);
+  }
 
-	
-	
-	public void update(E entity) throws ServiceException {
-		save(entity);
-	}
-	
+  public void update(E entity) throws ServiceException {
+    save(entity);
+  }
 
-	public void delete(E entity) throws ServiceException {
-		repository.delete(entity);
-	}
-	
-	
-	public void flush() {
-		repository.flush();
-	}
-	
+  public void delete(E entity) throws ServiceException {
+    repository.delete(entity);
+  }
 
-	
-	public List<E> list() {
-		return repository.findAll();
-	}
-	
+  public void flush() {
+    repository.flush();
+  }
 
-	public Long count() {
-		return repository.count();
-	}
-	
-	protected E saveAndFlush(E entity) {
-		return repository.saveAndFlush(entity);
-	}
+  public List<E> list() {
+    return repository.findAll();
+  }
 
+  public Long count() {
+    return repository.count();
+  }
+
+  protected E saveAndFlush(E entity) {
+    return repository.saveAndFlush(entity);
+  }
 }

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/order/OrderServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/order/OrderServiceImpl.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.order.InvoiceModule;
 import com.salesmanager.core.business.repositories.order.OrderRepository;
@@ -248,8 +248,8 @@ public class OrderServiceImpl  extends SalesManagerEntityServiceImpl<Long, Order
 
                             if(itemSubTotal==null) {
                                 itemSubTotal = new OrderTotal();
-                                itemSubTotal.setModule(Constants.OT_ITEM_PRICE_MODULE_CODE);
-                                itemSubTotal.setTitle(Constants.OT_ITEM_PRICE_MODULE_CODE);
+                                itemSubTotal.setModule(CoreBusinessConstants.OT_ITEM_PRICE_MODULE_CODE);
+                                itemSubTotal.setTitle(CoreBusinessConstants.OT_ITEM_PRICE_MODULE_CODE);
                                 itemSubTotal.setOrderTotalCode(price.getProductPrice().getCode());
                                 itemSubTotal.setOrderTotalType(OrderTotalType.PRODUCT);
                                 itemSubTotal.setSortOrder(0);
@@ -301,10 +301,10 @@ public class OrderServiceImpl  extends SalesManagerEntityServiceImpl<Long, Order
         grandTotal=grandTotal.add(subTotal);
 
         OrderTotal orderTotalSubTotal = new OrderTotal();
-        orderTotalSubTotal.setModule(Constants.OT_SUBTOTAL_MODULE_CODE);
+        orderTotalSubTotal.setModule(CoreBusinessConstants.OT_SUBTOTAL_MODULE_CODE);
         orderTotalSubTotal.setOrderTotalType(OrderTotalType.SUBTOTAL);
         orderTotalSubTotal.setOrderTotalCode("order.total.subtotal");
-        orderTotalSubTotal.setTitle(Constants.OT_SUBTOTAL_MODULE_CODE);
+        orderTotalSubTotal.setTitle(CoreBusinessConstants.OT_SUBTOTAL_MODULE_CODE);
         orderTotalSubTotal.setSortOrder(5);
         orderTotalSubTotal.setValue(subTotal);
 
@@ -316,10 +316,10 @@ public class OrderServiceImpl  extends SalesManagerEntityServiceImpl<Long, Order
 
 
 	            OrderTotal shippingSubTotal = new OrderTotal();
-	            shippingSubTotal.setModule(Constants.OT_SHIPPING_MODULE_CODE);
+	            shippingSubTotal.setModule(CoreBusinessConstants.OT_SHIPPING_MODULE_CODE);
 	            shippingSubTotal.setOrderTotalType(OrderTotalType.SHIPPING);
 	            shippingSubTotal.setOrderTotalCode("order.total.shipping");
-	            shippingSubTotal.setTitle(Constants.OT_SHIPPING_MODULE_CODE);
+	            shippingSubTotal.setTitle(CoreBusinessConstants.OT_SHIPPING_MODULE_CODE);
 	            shippingSubTotal.setSortOrder(100);
 
 	            orderTotals.add(shippingSubTotal);
@@ -337,10 +337,10 @@ public class OrderServiceImpl  extends SalesManagerEntityServiceImpl<Long, Order
             if(summary.getShippingSummary().getHandling()!=null && summary.getShippingSummary().getHandling().doubleValue()>0) {
                 if(shippingConfiguration.getHandlingFees()!=null && shippingConfiguration.getHandlingFees().doubleValue()>0) {
                     OrderTotal handlingubTotal = new OrderTotal();
-                    handlingubTotal.setModule(Constants.OT_HANDLING_MODULE_CODE);
+                    handlingubTotal.setModule(CoreBusinessConstants.OT_HANDLING_MODULE_CODE);
                     handlingubTotal.setOrderTotalType(OrderTotalType.HANDLING);
                     handlingubTotal.setOrderTotalCode("order.total.handling");
-                    handlingubTotal.setTitle(Constants.OT_HANDLING_MODULE_CODE);
+                    handlingubTotal.setTitle(CoreBusinessConstants.OT_HANDLING_MODULE_CODE);
                     //handlingubTotal.setText("order.total.handling");
                     handlingubTotal.setSortOrder(120);
                     handlingubTotal.setValue(summary.getShippingSummary().getHandling());
@@ -359,11 +359,11 @@ public class OrderServiceImpl  extends SalesManagerEntityServiceImpl<Long, Order
             for(TaxItem tax : taxes) {
 
                 OrderTotal taxLine = new OrderTotal();
-                taxLine.setModule(Constants.OT_TAX_MODULE_CODE);
+                taxLine.setModule(CoreBusinessConstants.OT_TAX_MODULE_CODE);
                 taxLine.setOrderTotalType(OrderTotalType.TAX);
                 taxLine.setOrderTotalCode(tax.getLabel());
                 taxLine.setSortOrder(taxCount);
-                taxLine.setTitle(Constants.OT_TAX_MODULE_CODE);
+                taxLine.setTitle(CoreBusinessConstants.OT_TAX_MODULE_CODE);
                 taxLine.setText(tax.getLabel());
                 taxLine.setValue(tax.getItemPrice());
 
@@ -380,10 +380,10 @@ public class OrderServiceImpl  extends SalesManagerEntityServiceImpl<Long, Order
 
         // grand total
         OrderTotal orderTotal = new OrderTotal();
-        orderTotal.setModule(Constants.OT_TOTAL_MODULE_CODE);
+        orderTotal.setModule(CoreBusinessConstants.OT_TOTAL_MODULE_CODE);
         orderTotal.setOrderTotalType(OrderTotalType.TOTAL);
         orderTotal.setOrderTotalCode("order.total.total");
-        orderTotal.setTitle(Constants.OT_TOTAL_MODULE_CODE);
+        orderTotal.setTitle(CoreBusinessConstants.OT_TOTAL_MODULE_CODE);
         //orderTotal.setText("order.total.total");
         orderTotal.setSortOrder(500);
         orderTotal.setValue(grandTotal);

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/payments/PaymentServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/payments/PaymentServiceImpl.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.order.OrderService;
 import com.salesmanager.core.business.services.reference.loader.ConfigurationModulesLoader;
@@ -81,7 +81,7 @@ public class PaymentServiceImpl implements PaymentService {
 	@Override
 	public List<IntegrationModule> getPaymentMethods(MerchantStore store) throws ServiceException {
 		
-		List<IntegrationModule> modules =  moduleConfigurationService.getIntegrationModules(Constants.PAYMENT_MODULES);
+		List<IntegrationModule> modules =  moduleConfigurationService.getIntegrationModules(CoreBusinessConstants.PAYMENT_MODULES);
 		List<IntegrationModule> returnModules = new ArrayList<IntegrationModule>();
 		
 		for(IntegrationModule module : modules) {
@@ -187,7 +187,7 @@ public class PaymentServiceImpl implements PaymentService {
 		try {
 		
 			Map<String,IntegrationConfiguration> modules = new HashMap<String,IntegrationConfiguration>();
-			MerchantConfiguration merchantConfiguration = merchantConfigurationService.getMerchantConfiguration(Constants.PAYMENT_MODULES, store);
+			MerchantConfiguration merchantConfiguration = merchantConfigurationService.getMerchantConfiguration(CoreBusinessConstants.PAYMENT_MODULES, store);
 			if(merchantConfiguration!=null) {
 				
 				if(!StringUtils.isBlank(merchantConfiguration.getValue())) {
@@ -224,7 +224,7 @@ public class PaymentServiceImpl implements PaymentService {
 		
 		try {
 			Map<String,IntegrationConfiguration> modules = new HashMap<String,IntegrationConfiguration>();
-			MerchantConfiguration merchantConfiguration = merchantConfigurationService.getMerchantConfiguration(Constants.PAYMENT_MODULES, store);
+			MerchantConfiguration merchantConfiguration = merchantConfigurationService.getMerchantConfiguration(CoreBusinessConstants.PAYMENT_MODULES, store);
 			if(merchantConfiguration!=null) {
 				if(!StringUtils.isBlank(merchantConfiguration.getValue())) {
 					
@@ -235,7 +235,7 @@ public class PaymentServiceImpl implements PaymentService {
 			} else {
 				merchantConfiguration = new MerchantConfiguration();
 				merchantConfiguration.setMerchantStore(store);
-				merchantConfiguration.setKey(Constants.PAYMENT_MODULES);
+				merchantConfiguration.setKey(CoreBusinessConstants.PAYMENT_MODULES);
 			}
 			modules.put(configuration.getModuleCode(), configuration);
 			
@@ -258,7 +258,7 @@ public class PaymentServiceImpl implements PaymentService {
 
 		try {
 			Map<String,IntegrationConfiguration> modules = new HashMap<String,IntegrationConfiguration>();
-			MerchantConfiguration merchantConfiguration = merchantConfigurationService.getMerchantConfiguration(Constants.PAYMENT_MODULES, store);
+			MerchantConfiguration merchantConfiguration = merchantConfigurationService.getMerchantConfiguration(CoreBusinessConstants.PAYMENT_MODULES, store);
 			if(merchantConfiguration!=null) {
 
 				if(!StringUtils.isBlank(merchantConfiguration.getValue())) {
@@ -527,10 +527,10 @@ public class PaymentServiceImpl implements PaymentService {
 		transactionService.create(transaction);
 		
         OrderTotal refund = new OrderTotal();
-        refund.setModule(Constants.OT_REFUND_MODULE_CODE);
-        refund.setText(Constants.OT_REFUND_MODULE_CODE);
-        refund.setTitle(Constants.OT_REFUND_MODULE_CODE);
-        refund.setOrderTotalCode(Constants.OT_REFUND_MODULE_CODE);
+        refund.setModule(CoreBusinessConstants.OT_REFUND_MODULE_CODE);
+        refund.setText(CoreBusinessConstants.OT_REFUND_MODULE_CODE);
+        refund.setTitle(CoreBusinessConstants.OT_REFUND_MODULE_CODE);
+        refund.setOrderTotalCode(CoreBusinessConstants.OT_REFUND_MODULE_CODE);
         refund.setOrderTotalType(OrderTotalType.REFUND);
         refund.setValue(amount);
         refund.setSortOrder(100);
@@ -544,7 +544,7 @@ public class PaymentServiceImpl implements PaymentService {
         //update ordertotal refund
         Set<OrderTotal> totals = order.getOrderTotal();
         for(OrderTotal total : totals) {
-        	if(total.getModule().equals(Constants.OT_TOTAL_MODULE_CODE)) {
+        	if(total.getModule().equals(CoreBusinessConstants.OT_TOTAL_MODULE_CODE)) {
         		total.setValue(orderTotal);
         	}
         }

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/reference/language/LanguageServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/reference/language/LanguageServiceImpl.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.repositories.reference.language.LanguageRepository;
 import com.salesmanager.core.business.services.common.generic.SalesManagerEntityServiceImpl;
@@ -74,7 +74,7 @@ public class LanguageServiceImpl extends SalesManagerEntityServiceImpl<Integer, 
 			LOGGER.error("Cannot convert locale " + locale.getLanguage() + " to language");
 		}
 		if(language == null) {
-			language = new Language(Constants.DEFAULT_LANGUAGE);
+			language = new Language(CoreBusinessConstants.DEFAULT_LANGUAGE);
 		}
 		return language;
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/reference/zone/ZoneServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/reference/zone/ZoneServiceImpl.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.repositories.reference.zone.ZoneRepository;
 import com.salesmanager.core.business.services.common.generic.SalesManagerEntityServiceImpl;
@@ -73,12 +73,12 @@ public class ZoneServiceImpl extends SalesManagerEntityServiceImpl<Long, Zone> i
 		List<Zone> zones = null;
 		try {
 			
-			String countryCode = Constants.DEFAULT_COUNTRY;
+			String countryCode = CoreBusinessConstants.DEFAULT_COUNTRY;
 			if(country!=null) {
 				countryCode = country.getIsoCode();
 			}
 
-			String cacheKey = ZONE_CACHE_PREFIX + countryCode + Constants.UNDERSCORE + language.getCode();
+			String cacheKey = ZONE_CACHE_PREFIX + countryCode + CoreBusinessConstants.UNDERSCORE + language.getCode();
 			
 			zones = (List<Zone>) cache.getFromCache(cacheKey);
 
@@ -116,7 +116,7 @@ public class ZoneServiceImpl extends SalesManagerEntityServiceImpl<Long, Zone> i
 		try {
 			
 
-			String cacheKey = ZONE_CACHE_PREFIX + countryCode + Constants.UNDERSCORE + language.getCode();
+			String cacheKey = ZONE_CACHE_PREFIX + countryCode + CoreBusinessConstants.UNDERSCORE + language.getCode();
 			
 			zones = (List<Zone>) cache.getFromCache(cacheKey);
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/search/SearchServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/search/SearchServiceImpl.java
@@ -27,7 +27,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 
 import com.salesmanager.core.business.configuration.ApplicationSearchConfiguration;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.catalog.inventory.ProductInventoryService;
 import com.salesmanager.core.business.utils.CoreConfiguration;
@@ -124,7 +124,7 @@ public class SearchServiceImpl implements com.salesmanager.core.business.service
 		Validate.notNull(product.getId(), "Product.id cannot be null");
 
 		if (configuration.getProperty(INDEX_PRODUCTS) == null
-				|| configuration.getProperty(INDEX_PRODUCTS).equals(Constants.FALSE) || searchModule == null) {
+				|| configuration.getProperty(INDEX_PRODUCTS).equals(CoreBusinessConstants.FALSE) || searchModule == null) {
 			return;
 		}
 
@@ -378,7 +378,7 @@ public class SearchServiceImpl implements com.salesmanager.core.business.service
 	public void deleteDocument(MerchantStore store, Product product) throws ServiceException {
 
 		if (configuration.getProperty(INDEX_PRODUCTS) == null
-				|| configuration.getProperty(INDEX_PRODUCTS).equals(Constants.FALSE) || searchModule == null) {
+				|| configuration.getProperty(INDEX_PRODUCTS).equals(CoreBusinessConstants.FALSE) || searchModule == null) {
 			return;
 		}
 
@@ -397,7 +397,7 @@ public class SearchServiceImpl implements com.salesmanager.core.business.service
 			throws ServiceException {
 
 		if (configuration.getProperty(INDEX_PRODUCTS) == null
-				|| configuration.getProperty(INDEX_PRODUCTS).equals(Constants.FALSE) || searchModule == null) {
+				|| configuration.getProperty(INDEX_PRODUCTS).equals(CoreBusinessConstants.FALSE) || searchModule == null) {
 			return null;
 		}
 
@@ -413,7 +413,7 @@ public class SearchServiceImpl implements com.salesmanager.core.business.service
 			int startIndex) throws ServiceException {
 
 		if (configuration.getProperty(INDEX_PRODUCTS) == null
-				|| configuration.getProperty(INDEX_PRODUCTS).equals(Constants.FALSE) || searchModule == null) {
+				|| configuration.getProperty(INDEX_PRODUCTS).equals(CoreBusinessConstants.FALSE) || searchModule == null) {
 			return null;
 		}
 
@@ -429,7 +429,7 @@ public class SearchServiceImpl implements com.salesmanager.core.business.service
 	public Optional<Document> getDocument(String language, MerchantStore store, Long productId)
 			throws ServiceException {
 		if (configuration.getProperty(INDEX_PRODUCTS) == null
-				|| configuration.getProperty(INDEX_PRODUCTS).equals(Constants.FALSE) || searchModule == null) {
+				|| configuration.getProperty(INDEX_PRODUCTS).equals(CoreBusinessConstants.FALSE) || searchModule == null) {
 			return null;
 		}
 

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/system/EmailServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/system/EmailServiceImpl.java
@@ -5,7 +5,7 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.modules.email.Email;
 import com.salesmanager.core.business.modules.email.EmailConfig;
@@ -34,7 +34,7 @@ public class EmailServiceImpl implements EmailService {
 	@Override
 	public EmailConfig getEmailConfiguration(MerchantStore store) throws ServiceException {
 		
-		MerchantConfiguration configuration = merchantConfigurationService.getMerchantConfiguration(Constants.EMAIL_CONFIG, store);
+		MerchantConfiguration configuration = merchantConfigurationService.getMerchantConfiguration(CoreBusinessConstants.EMAIL_CONFIG, store);
 		EmailConfig emailConfig = null;
 		if(configuration!=null) {
 			String value = configuration.getValue();
@@ -52,11 +52,11 @@ public class EmailServiceImpl implements EmailService {
 	
 	@Override
 	public void saveEmailConfiguration(EmailConfig emailConfig, MerchantStore store) throws ServiceException {
-		MerchantConfiguration configuration = merchantConfigurationService.getMerchantConfiguration(Constants.EMAIL_CONFIG, store);
+		MerchantConfiguration configuration = merchantConfigurationService.getMerchantConfiguration(CoreBusinessConstants.EMAIL_CONFIG, store);
 		if(configuration==null) {
 			configuration = new MerchantConfiguration();
 			configuration.setMerchantStore(store);
-			configuration.setKey(Constants.EMAIL_CONFIG);
+			configuration.setKey(CoreBusinessConstants.EMAIL_CONFIG);
 		}
 		
 		String value = emailConfig.toJSONString();

--- a/sm-core/src/main/java/com/salesmanager/core/business/services/system/ModuleConfigurationServiceImpl.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/services/system/ModuleConfigurationServiceImpl.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.repositories.system.ModuleConfigurationRepository;
 import com.salesmanager.core.business.services.common.generic.SalesManagerEntityServiceImpl;
@@ -130,7 +130,7 @@ public class ModuleConfigurationServiceImpl extends SalesManagerEntityServiceImp
 					for (ModuleStarter mod : this.payments) {
 						IntegrationModule m = new IntegrationModule();
 						m.setCode(mod.getUniqueCode());
-						m.setModule(Constants.PAYMENT_MODULES);
+						m.setModule(CoreBusinessConstants.PAYMENT_MODULES);
 						
 						
 						if(CollectionUtils.isNotEmpty(mod.getSupportedCountry())) {

--- a/sm-core/src/main/java/com/salesmanager/core/business/utils/CatalogServiceHelper.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/utils/CatalogServiceHelper.java
@@ -1,6 +1,6 @@
 package com.salesmanager.core.business.utils;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.attribute.*;
 import com.salesmanager.core.model.catalog.product.availability.ProductAvailability;
@@ -55,7 +55,7 @@ public class CatalogServiceHelper {
 		Set<ProductAvailability> availabilities = product.getAvailabilities();
 		Set<ProductAvailability> productAvailabilities = new HashSet<ProductAvailability>();
 
-		Optional<ProductAvailability> defaultAvailability = availabilities.stream().filter(productAvailability -> productAvailability.getRegion().equals(Constants.ALL_REGIONS)).findFirst();
+		Optional<ProductAvailability> defaultAvailability = availabilities.stream().filter(productAvailability -> productAvailability.getRegion().equals(CoreBusinessConstants.ALL_REGIONS)).findFirst();
 		Optional<ProductAvailability> localeAvailability = availabilities.stream().filter(productAvailability -> productAvailability.getRegion().equals(locale.getCountry())).findFirst();
 		if (defaultAvailability.isPresent()) {
 			productAvailabilities.add(defaultAvailability.get());

--- a/sm-core/src/main/java/com/salesmanager/core/business/utils/ProductPriceUtils.java
+++ b/sm-core/src/main/java/com/salesmanager/core/business/utils/ProductPriceUtils.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.attribute.ProductAttribute;
@@ -188,7 +188,7 @@ public class ProductPriceUtils {
 
 		for (ProductAvailability availability : variant.getAvailabilities()) {
 			if (!StringUtils.isEmpty(availability.getRegion())
-					&& availability.getRegion().equals(Constants.ALL_REGIONS)) {// TODO REL 2.1 accept a region
+					&& availability.getRegion().equals(CoreBusinessConstants.ALL_REGIONS)) {// TODO REL 2.1 accept a region
 				Set<ProductPrice> prices = availability.getPrices();
 				for (ProductPrice price : prices) {
 
@@ -257,7 +257,7 @@ public class ProductPriceUtils {
 			return "";
 		}
 
-		NumberFormat nf = NumberFormat.getInstance(Constants.DEFAULT_LOCALE);
+		NumberFormat nf = NumberFormat.getInstance(CoreBusinessConstants.DEFAULT_LOCALE);
 
 		nf.setMaximumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
 		nf.setMinimumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
@@ -272,7 +272,7 @@ public class ProductPriceUtils {
 			return "";
 		}
 
-		NumberFormat nf = NumberFormat.getInstance(Constants.DEFAULT_LOCALE);
+		NumberFormat nf = NumberFormat.getInstance(CoreBusinessConstants.DEFAULT_LOCALE);
 
 		nf.setMaximumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
 		nf.setMinimumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
@@ -296,8 +296,8 @@ public class ProductPriceUtils {
 			return "";
 		}
 
-		Currency currency = Constants.DEFAULT_CURRENCY;
-		Locale locale = Constants.DEFAULT_LOCALE;
+		Currency currency = CoreBusinessConstants.DEFAULT_CURRENCY;
+		Locale locale = CoreBusinessConstants.DEFAULT_LOCALE;
 
 		try {
 			currency = store.getCurrency().getCurrency();
@@ -351,7 +351,7 @@ public class ProductPriceUtils {
 		NumberFormat nf = null;
 
 		Currency currency = store.getCurrency().getCurrency();
-		nf = NumberFormat.getInstance(Constants.DEFAULT_LOCALE);
+		nf = NumberFormat.getInstance(CoreBusinessConstants.DEFAULT_LOCALE);
 		nf.setMaximumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
 		nf.setMinimumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
 		nf.setCurrency(currency);
@@ -379,7 +379,7 @@ public class ProductPriceUtils {
 		NumberFormat nf = null;
 
 		Currency curr = currency.getCurrency();
-		nf = NumberFormat.getInstance(Constants.DEFAULT_LOCALE);
+		nf = NumberFormat.getInstance(CoreBusinessConstants.DEFAULT_LOCALE);
 		nf.setMaximumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
 		nf.setMinimumFractionDigits(Integer.parseInt(Character.toString(DECIMALCOUNT)));
 		nf.setCurrency(curr);
@@ -476,7 +476,7 @@ public class ProductPriceUtils {
 
 			if (matcher.matches()) {
 
-				Locale locale = Constants.DEFAULT_LOCALE;
+				Locale locale = CoreBusinessConstants.DEFAULT_LOCALE;
 				// TODO validate amount using old test case
 				if (DECIMALPOINT == ',') {
 					locale = Locale.GERMAN;
@@ -577,7 +577,7 @@ public class ProductPriceUtils {
 
 		for (ProductAvailability availability : availabilities) {
 			if (!StringUtils.isEmpty(availability.getRegion())
-					&& availability.getRegion().equals(Constants.ALL_REGIONS)) {// TODO REL 2.1 accept a region
+					&& availability.getRegion().equals(CoreBusinessConstants.ALL_REGIONS)) {// TODO REL 2.1 accept a region
 				Set<ProductPrice> prices = availability.getPrices();
 				for (ProductPrice price : prices) {
 

--- a/sm-core/src/test/java/com/salesmanager/test/modules/ModulesTest.java
+++ b/sm-core/src/test/java/com/salesmanager/test/modules/ModulesTest.java
@@ -6,7 +6,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.services.system.ModuleConfigurationService;
 import com.salesmanager.core.model.system.IntegrationModule;
 
@@ -18,7 +18,7 @@ public class ModulesTest extends com.salesmanager.test.common.AbstractSalesManag
 	
 	@Test
 	public void testModulesConfigurations() throws Exception {
-		List<IntegrationModule> modules = moduleConfigurationService.getIntegrationModules(Constants.PAYMENT_MODULES);
+		List<IntegrationModule> modules = moduleConfigurationService.getIntegrationModules(CoreBusinessConstants.PAYMENT_MODULES);
 		
 		Assert.assertNotNull(modules);
 	}

--- a/sm-core/src/test/java/com/salesmanager/test/order/OrderTest.java
+++ b/sm-core/src/test/java/com/salesmanager/test/order/OrderTest.java
@@ -1,6 +1,6 @@
 package com.salesmanager.test.order;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.model.catalog.category.Category;
 import com.salesmanager.core.model.catalog.category.CategoryDescription;
@@ -346,7 +346,7 @@ public class OrderTest extends com.salesmanager.test.common.AbstractSalesManager
 		
 		OrderTotal subTotal = new OrderTotal();
 		subTotal.setOrder(order);
-		subTotal.setOrderTotalCode(Constants.OT_SUBTOTAL_MODULE_CODE);
+		subTotal.setOrderTotalCode(CoreBusinessConstants.OT_SUBTOTAL_MODULE_CODE);
 		subTotal.setSortOrder(0);
 		subTotal.setTitle("Sub Total");
 		subTotal.setValue(dprice.getProductPriceAmount());
@@ -356,7 +356,7 @@ public class OrderTest extends com.salesmanager.test.common.AbstractSalesManager
 		
 		OrderTotal total = new OrderTotal();
 		total.setOrder(order);
-		total.setOrderTotalCode(Constants.OT_TOTAL_MODULE_CODE);
+		total.setOrderTotalCode(CoreBusinessConstants.OT_TOTAL_MODULE_CODE);
 		total.setSortOrder(1);
 		total.setTitle("Total");
 		total.setValue(dprice.getProductPriceAmount());

--- a/sm-shop-model/pom.xml
+++ b/sm-shop-model/pom.xml
@@ -76,6 +76,13 @@
       <artifactId>springfox-swagger2</artifactId>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+   			<groupId>org.projectlombok</groupId>
+  			<artifactId>lombok</artifactId>
+    		<version>1.18.38</version>
+		</dependency>
+
   </dependencies>
 
   <build>

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/catalog/catalog/CatalogEntity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/catalog/catalog/CatalogEntity.java
@@ -1,36 +1,22 @@
 package com.salesmanager.shop.model.catalog.catalog;
 
 import java.io.Serializable;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 
-import com.salesmanager.shop.model.entity.Entity;
+import com.salesmanager.shop.model.constants.TableNameConstant;
 
-public class CatalogEntity extends Entity implements Serializable {
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-
-	private boolean visible;
-	private boolean defaultCatalog;
-	private String code;
-	public boolean isVisible() {
-		return visible;
-	}
-	public void setVisible(boolean visible) {
-		this.visible = visible;
-	}
-	public boolean isDefaultCatalog() {
-		return defaultCatalog;
-	}
-	public void setDefaultCatalog(boolean defaultCatalog) {
-		this.defaultCatalog = defaultCatalog;
-	}
-	public String getCode() {
-		return code;
-	}
-	public void setCode(String code) {
-		this.code = code;
-	}
-
+@Entity     
+@Table(name = TableNameConstant.CATALOG)
+@Getter
+@Setter
+@NoArgsConstructor
+public class CatalogEntity extends com.salesmanager.shop.model.entity.Entity {
+    private boolean visible;
+    private boolean defaultCatalog;
+    private String code;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/constants/SmShopModelLiterals.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/constants/SmShopModelLiterals.java
@@ -1,0 +1,8 @@
+package com.salesmanager.shop.model.constants;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class SmShopModelLiterals {
+    public static final long SERIAL_VERSION_UID = 1L;
+}

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/constants/SmShopModelLiterals.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/constants/SmShopModelLiterals.java
@@ -5,4 +5,6 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class SmShopModelLiterals {
     public static final long SERIAL_VERSION_UID = 1L;
+    public static final int  ZERO = 0;
+    public static final long  ZERO_LONG = 0L;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/constants/TableNameConstant.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/constants/TableNameConstant.java
@@ -1,0 +1,10 @@
+package com.salesmanager.shop.model.constants;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class TableNameConstant {
+
+
+ public static final String CATALOG = "catalog";
+}

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/content/ObjectContent.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/content/ObjectContent.java
@@ -1,56 +1,28 @@
 package com.salesmanager.shop.model.content;
 
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
 import com.salesmanager.shop.model.entity.ResourceUrlAccess;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+/**
+ * Deprecated: Represents content object with SEO-friendly URL slug.
+ *
+ * @deprecated Replaced by newer content handling models.
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
 @Deprecated
+@Getter
+@Setter
+@NoArgsConstructor
 public class ObjectContent extends ContentPath implements ResourceUrlAccess {
 
-  /**
-   * 
-   */
-  private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
 
-  private String slug;
-  private String metaDetails;
-  private String title;
-  private String pageContent;
-  private String language;
-  public String getPageContent() {
-      return pageContent;
-  }
-  public void setPageContent(String pageContent) {
-      this.pageContent = pageContent;
-  }
-
-  public String getSlug() {
-    return slug;
-  }
-
-  public void setSlug(String slug) {
-    this.slug = slug;
-  }
-
-  public String getMetaDetails() {
-    return metaDetails;
-  }
-
-  public void setMetaDetails(String metaDetails) {
-    this.metaDetails = metaDetails;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public void setTitle(String title) {
-    this.title = title;
-  }
-  public String getLanguage() {
-    return language;
-  }
-  public void setLanguage(String language) {
-    this.language = language;
-  }
-
-
+    private String slug;
+    private String metaDetails;
+    private String title;
+    private String pageContent;
+    private String language;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/CodeEntity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/CodeEntity.java
@@ -1,17 +1,16 @@
 package com.salesmanager.shop.model.entity;
 
-public class CodeEntity extends Entity {
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-	private String code;
-	public String getCode() {
-		return code;
-	}
-	public void setCode(String code) {
-		this.code = code;
-	}
+/**
+ * @lastUpdated 2025-09-07 By Kuntal 
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class CodeEntity extends Entity {
+private String code;
 
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/Entity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/Entity.java
@@ -2,23 +2,23 @@ package com.salesmanager.shop.model.entity;
 
 import java.io.Serializable;
 
-public class Entity implements Serializable {
-  
-    public Entity() {}
-    public Entity(Long id) {
-    	this.id = id;
-    }
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-	private Long id = 0L;
-	public void setId(Long id) {
-		this.id = id;
-	}
-	public Long getId() {
-		return id;
-	}
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @lastUpdated 2025-09-07 By Kuntal 
+ */
+@Getter
+@Setter
+@NoArgsConstructor     
+@AllArgsConstructor 
+public class Entity implements Serializable {
+
+	private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
+
+    private Long id = 0L;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/Entity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/Entity.java
@@ -19,6 +19,5 @@ import lombok.Setter;
 public class Entity implements Serializable {
 
 	private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
-
-    private Long id = 0L;
+    private Long id = SmShopModelLiterals.ZERO_LONG;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/EntityExists.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/EntityExists.java
@@ -2,28 +2,24 @@ package com.salesmanager.shop.model.entity;
 
 import java.io.Serializable;
 
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @lastUpdated 2025-09-07 By Kuntal 
+ */
+@Getter
+@Setter
+@NoArgsConstructor       
+@AllArgsConstructor 
 public class EntityExists implements Serializable {
 	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
+
 	private boolean exists = false;
-	
-	public EntityExists() {
-		
-	}
-
-	public EntityExists(boolean exists) {
-		this.exists = exists;
-	}
-
-	public boolean isExists() {
-		return exists;
-	}
-
-	public void setExists(boolean exists) {
-		this.exists = exists;
-	}
 
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ListCriteria.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ListCriteria.java
@@ -1,30 +1,19 @@
 package com.salesmanager.shop.model.entity;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /**
  * Used for filtering lists
  * @author carlsamson
- *
+ * @lastUpdated 2025-09-07 By Kuntal
  */
-public class ListCriteria {
 
+@Getter
+@Setter
+@NoArgsConstructor
+public class ListCriteria {
 	private String name;
 	private String type;
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/NameEntity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/NameEntity.java
@@ -2,26 +2,27 @@ package com.salesmanager.shop.model.entity;
 
 import javax.validation.constraints.NotEmpty;
 
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 /**
  * Used as an input request object where an entity name and or id is important
  * @author carlsamson
- *
+ * @lastUpdated 2025-09-07 By Kuntal
  */
+@Getter
+@Setter
+@NoArgsConstructor
 public class NameEntity extends Entity {
 	
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 1L;
-	@NotEmpty
-	private String name;
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
+	private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
+		@NotEmpty
+    private String name;
 
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableAudit.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableAudit.java
@@ -1,26 +1,18 @@
 package com.salesmanager.shop.model.entity;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @lastUpdated 2025-09-07 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
 public class ReadableAudit {
 
 	private String created;
 	private String modified;
 	private String user;
-	public String getCreated() {
-		return created;
-	}
-	public void setCreated(String created) {
-		this.created = created;
-	}
-	public String getModified() {
-		return modified;
-	}
-	public void setModified(String modified) {
-		this.modified = modified;
-	}
-	public String getUser() {
-		return user;
-	}
-	public void setUser(String user) {
-		this.user = user;
-	}
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableDescription.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableDescription.java
@@ -1,12 +1,18 @@
 package com.salesmanager.shop.model.entity;
 
 import com.salesmanager.shop.model.catalog.NamedEntity;
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+/**
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
 public class ReadableDescription extends NamedEntity {
-
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
 
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableEntity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableEntity.java
@@ -1,10 +1,18 @@
 package com.salesmanager.shop.model.entity;
 
-public class ReadableEntity extends Entity {
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
 
-  /**
-   * 
-   */
-  private static final long serialVersionUID = 1L;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReadableEntity extends Entity {
+	private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
 
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableEntityList.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableEntityList.java
@@ -2,20 +2,24 @@ package com.salesmanager.shop.model.entity;
 
 import java.util.List;
 
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Generic wrapper for a list of readable entities.
+ *
+ * @param <T> the type of items in the list
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
 public class ReadableEntityList<T> extends ReadableList {
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-	private List<T> items;
 
-	public List<T> getItems() {
-		return items;
-	}
+    private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
 
-	public void setItems(List<T> items) {
-		this.items = items;
-	}
-
+    private List<T> items;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableList.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ReadableList.java
@@ -2,47 +2,25 @@ package com.salesmanager.shop.model.entity;
 
 import java.io.Serializable;
 
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Abstract base class representing a paginated list of readable entities.
+ *
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
 public abstract class ReadableList implements Serializable {
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-	private int totalPages;//totalPages
-	private int number;//number of record in current page
-	private long recordsTotal;//total number of records in db
-	private int recordsFiltered;
 
-	public int getTotalPages() {
-		return totalPages;
-	}
-
-	public void setTotalPages(int totalCount) {
-		this.totalPages = totalCount;
-	}
-
-	public long getRecordsTotal() {
-		return recordsTotal;
-	}
-
-	public void setRecordsTotal(long recordsTotal) {
-		this.recordsTotal = recordsTotal;
-	}
-
-	public int getRecordsFiltered() {
-		return recordsFiltered;
-	}
-
-	public void setRecordsFiltered(int recordsFiltered) {
-		this.recordsFiltered = recordsFiltered;
-	}
-
-	public int getNumber() {
-		return number;
-	}
-
-	public void setNumber(int number) {
-		this.number = number;
-	}
-
+    private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
+    private int totalPages;
+    private int number;
+    private long recordsTotal;
+    private int recordsFiltered;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ServiceEntity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ServiceEntity.java
@@ -1,21 +1,21 @@
 package com.salesmanager.shop.model.entity;
 
-public abstract class ServiceEntity {
-	
-	private int status = 0;
-	private String message = null;
-	
-	public int getStatus() {
-		return status;
-	}
-	public void setStatus(int status) {
-		this.status = status;
-	}
-	public String getMessage() {
-		return message;
-	}
-	public void setMessage(String message) {
-		this.message = message;
-	}
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Abstract base class for service entities with status and message.
+ *
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public abstract class ServiceEntity {
+
+    private int status = SmShopModelLiterals.ZERO;
+    private String message;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ShopEntity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ShopEntity.java
@@ -2,20 +2,19 @@ package com.salesmanager.shop.model.entity;
 
 import java.io.Serializable;
 
-public abstract class ShopEntity extends Entity implements Serializable {
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-	private String language;
-	
-	public void setLanguage(String language) {
-		this.language = language;
-	}
-	public String getLanguage() {
-		return language;
-	}
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+/**
+ * Abstract shop entity that includes language support.
+ *
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public abstract class ShopEntity extends Entity {
 
+    private String language;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/UniqueEntity.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/UniqueEntity.java
@@ -3,31 +3,27 @@ package com.salesmanager.shop.model.entity;
 import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Represents an entity identified by a unique value and a merchant.
+ *
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
 public class UniqueEntity implements Serializable {
-  
-  /**
-   * 
-   */
-  private static final long serialVersionUID = 1L;
-  @NotNull
-  private String unique;
-  @NotNull
-  private String merchant;
 
-  public String getUnique() {
-    return unique;
-  }
+    private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
 
-  public void setUnique(String unique) {
-    this.unique = unique;
-  }
+    @NotNull
+    private String unique;
 
-  public String getMerchant() {
-    return merchant;
-  }
-
-  public void setMerchant(String merchant) {
-    this.merchant = merchant;
-  }
-
+    @NotNull
+    private String merchant;
 }

--- a/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ValueList.java
+++ b/sm-shop-model/src/main/java/com/salesmanager/shop/model/entity/ValueList.java
@@ -4,18 +4,23 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.salesmanager.shop.model.constants.SmShopModelLiterals;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Simple wrapper for a list of string values.
+ *
+ * @lastUpdated 2025-09-08 By Kuntal
+ */
+@Getter
+@Setter
+@NoArgsConstructor
 public class ValueList implements Serializable {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-	private List<String> values = new ArrayList<String>();
-	public List<String> getValues() {
-		return values;
-	}
-	public void setValues(List<String> values) {
-		this.values = values;
-	}
+    private static final long serialVersionUID = SmShopModelLiterals.SERIAL_VERSION_UID;
 
+    private List<String> values = new ArrayList<>();
 }

--- a/sm-shop/pom.xml
+++ b/sm-shop/pom.xml
@@ -142,6 +142,13 @@
 			<version>1.6.0</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+   			<groupId>org.projectlombok</groupId>
+  			<artifactId>lombok</artifactId>
+    		<version>1.18.38</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/sm-shop/src/main/java/com/salesmanager/shop/application/config/MerchantStoreArgumentResolver.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/application/config/MerchantStoreArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.salesmanager.shop.application.config;
 
-import static com.salesmanager.core.business.constants.Constants.DEFAULT_STORE;
+import static com.salesmanager.core.business.constants.CoreBusinessConstants.DEFAULT_STORE;
 
 import java.util.Optional;
 

--- a/sm-shop/src/main/java/com/salesmanager/shop/mapper/cart/ReadableShoppingCartMapper.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/mapper/cart/ReadableShoppingCartMapper.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
 import com.salesmanager.core.business.services.catalog.product.attribute.ProductAttributeService;
 import com.salesmanager.core.business.services.catalog.product.variant.ProductVariantService;
@@ -261,7 +261,7 @@ public class ReadableShoppingCartMapper implements Mapper<ShoppingCart, Readable
 			if (CollectionUtils.isNotEmpty(orderSummary.getTotals())) {
 
 				if (orderSummary.getTotals().stream()
-						.filter(t -> Constants.OT_DISCOUNT_TITLE.equals(t.getOrderTotalCode())).count() == 0) {
+						.filter(t -> CoreBusinessConstants.OT_DISCOUNT_TITLE.equals(t.getOrderTotalCode())).count() == 0) {
 					// no promo coupon applied
 					destination.setPromoCode(null);
 

--- a/sm-shop/src/main/java/com/salesmanager/shop/mapper/catalog/product/PersistableProductAvailabilityMapper.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/mapper/catalog/product/PersistableProductAvailabilityMapper.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.model.catalog.product.availability.ProductAvailability;
 import com.salesmanager.core.model.catalog.product.price.ProductPrice;
 import com.salesmanager.core.model.catalog.product.price.ProductPriceDescription;
@@ -30,7 +30,7 @@ public class PersistableProductAvailabilityMapper implements Mapper<PersistableP
 
 		try {
 
-			destination.setRegion(Constants.ALL_REGIONS);
+			destination.setRegion(CoreBusinessConstants.ALL_REGIONS);
 
 			destination.setProductQuantity(source.getQuantity());
 			destination.setProductQuantityOrderMin(1);

--- a/sm-shop/src/main/java/com/salesmanager/shop/mapper/catalog/product/PersistableProductDefinitionMapper.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/mapper/catalog/product/PersistableProductDefinitionMapper.java
@@ -13,7 +13,7 @@ import org.apache.commons.lang3.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ConversionException;
 import com.salesmanager.core.business.services.catalog.category.CategoryService;
 import com.salesmanager.core.business.services.catalog.product.manufacturer.ManufacturerService;
@@ -187,7 +187,7 @@ public class PersistableProductDefinitionMapper implements Mapper<PersistablePro
 		      productAvailability.setProductQuantity(source.getQuantity());
 			  productAvailability.setProductQuantityOrderMin(1);
 			  productAvailability.setProductQuantityOrderMax(1);
-			  productAvailability.setRegion(Constants.ALL_REGIONS);
+			  productAvailability.setRegion(CoreBusinessConstants.ALL_REGIONS);
 			  productAvailability.setAvailable(Boolean.valueOf(destination.isAvailable()));
 			  productAvailability.setProductStatus(source.isCanBePurchased());
 		    }

--- a/sm-shop/src/main/java/com/salesmanager/shop/mapper/catalog/product/PersistableProductMapper.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/mapper/catalog/product/PersistableProductMapper.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ConversionException;
 import com.salesmanager.core.business.services.catalog.category.CategoryService;
 import com.salesmanager.core.business.services.catalog.product.manufacturer.ManufacturerService;
@@ -303,7 +303,7 @@ public class PersistableProductMapper implements Mapper<PersistableProduct, Prod
 	}
 	
 	private ProductAvailability defaultAvailability(List <ProductAvailability> availabilityList) {
-		return availabilityList.stream().filter(a -> a.getRegion() != null && a.getRegion().equals(Constants.ALL_REGIONS)).findFirst().get();
+		return availabilityList.stream().filter(a -> a.getRegion() != null && a.getRegion().equals(CoreBusinessConstants.ALL_REGIONS)).findFirst().get();
 	}
 	
 

--- a/sm-shop/src/main/java/com/salesmanager/shop/mapper/inventory/PersistableInventoryMapper.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/mapper/inventory/PersistableInventoryMapper.java
@@ -17,7 +17,7 @@ import org.jsoup.helper.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ConversionException;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.catalog.product.ProductService;
@@ -224,7 +224,7 @@ public class PersistableInventoryMapper implements Mapper<PersistableInventory, 
 	}
 
 	private String getRegion(PersistableInventory source) {
-		return Optional.ofNullable(source.getRegion()).filter(StringUtils::isNotBlank).orElse(Constants.ALL_REGIONS);
+		return Optional.ofNullable(source.getRegion()).filter(StringUtils::isNotBlank).orElse(CoreBusinessConstants.ALL_REGIONS);
 	}
 
 	private ProductPriceDescription getDescription(

--- a/sm-shop/src/main/java/com/salesmanager/shop/mapper/inventory/PersistableProductPriceMapper.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/mapper/inventory/PersistableProductPriceMapper.java
@@ -14,7 +14,7 @@ import org.jsoup.helper.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.catalog.product.ProductService;
 import com.salesmanager.core.business.services.catalog.product.availability.ProductAvailabilityService;
@@ -86,7 +86,7 @@ public class PersistableProductPriceMapper implements Mapper<PersistableProductP
 				if (!CollectionUtils.isEmpty(existing)) {
 					// find default availability
 					Optional<ProductAvailability> avail = existing.stream()
-							.filter(a -> a.getRegion() != null && a.getRegion().equals(Constants.ALL_REGIONS))
+							.filter(a -> a.getRegion() != null && a.getRegion().equals(CoreBusinessConstants.ALL_REGIONS))
 							.findAny();
 					if (avail.isPresent()) {
 						availability = avail.get();
@@ -117,7 +117,7 @@ public class PersistableProductPriceMapper implements Mapper<PersistableProductP
 
 				availability = new ProductAvailability();
 				availability.setProduct(product);
-				availability.setRegion(Constants.ALL_REGIONS);
+				availability.setRegion(CoreBusinessConstants.ALL_REGIONS);
 			}
 
 			destination.setProductAvailability(availability);

--- a/sm-shop/src/main/java/com/salesmanager/shop/mapper/order/ReadableOrderTotalMapper.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/mapper/order/ReadableOrderTotalMapper.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
 import com.salesmanager.core.model.merchant.MerchantStore;
 import com.salesmanager.core.model.order.OrderTotal;
@@ -58,7 +58,7 @@ public class ReadableOrderTotalMapper implements Mapper<OrderTotal, ReadableOrde
 			target.setTotal(pricingService.getDisplayAmount(source.getValue(), store));
 
 			if (!StringUtils.isBlank(source.getOrderTotalCode())) {
-				if (Constants.OT_DISCOUNT_TITLE.equals(source.getOrderTotalCode())) {
+				if (CoreBusinessConstants.OT_DISCOUNT_TITLE.equals(source.getOrderTotalCode())) {
 					target.setDiscounted(true);
 				}
 			}

--- a/sm-shop/src/main/java/com/salesmanager/shop/populator/order/ReadableOrderTotalPopulator.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/populator/order/ReadableOrderTotalPopulator.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ConversionException;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
 import com.salesmanager.core.business.utils.AbstractDataPopulator;
@@ -53,7 +53,7 @@ public class ReadableOrderTotalPopulator extends
 				target.setTotal(pricingService.getDisplayAmount(source.getValue(), store));
 				
 				if(!StringUtils.isBlank(source.getOrderTotalCode())) {
-					if(Constants.OT_DISCOUNT_TITLE.equals(source.getOrderTotalCode())) {
+					if(CoreBusinessConstants.OT_DISCOUNT_TITLE.equals(source.getOrderTotalCode())) {
 						target.setDiscounted(true);
 					}
 				}

--- a/sm-shop/src/main/java/com/salesmanager/shop/populator/store/PersistableMerchantStorePopulator.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/populator/store/PersistableMerchantStorePopulator.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.springframework.stereotype.Component;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ConversionException;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.merchant.MerchantStoreService;
@@ -112,7 +112,7 @@ public class PersistableMerchantStorePopulator extends AbstractDataPopulator<Per
 				Currency c = currencyService.getByCode(source.getCurrency());
 				target.setCurrency(c);
 			} else {
-				target.setCurrency(currencyService.getByCode(Constants.DEFAULT_CURRENCY.getCurrencyCode()));
+				target.setCurrency(currencyService.getByCode(CoreBusinessConstants.DEFAULT_CURRENCY.getCurrencyCode()));
 			}
 			
 			List<String> languages = source.getSupportedLanguages();

--- a/sm-shop/src/main/java/com/salesmanager/shop/populator/user/ReadableUserPopulator.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/populator/user/ReadableUserPopulator.java
@@ -2,7 +2,7 @@ package com.salesmanager.shop.populator.user;
 
 import org.apache.commons.lang3.Validate;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ConversionException;
 import com.salesmanager.core.business.utils.AbstractDataPopulator;
 import com.salesmanager.core.model.merchant.MerchantStore;
@@ -41,7 +41,7 @@ public class ReadableUserPopulator extends AbstractDataPopulator<User, ReadableU
     }
 
     // set default language
-    target.setDefaultLanguage(Constants.DEFAULT_LANGUAGE);
+    target.setDefaultLanguage(CoreBusinessConstants.DEFAULT_LANGUAGE);
 
     if (source.getDefaultLanguage() != null)
       target.setDefaultLanguage(source.getDefaultLanguage().getCode());

--- a/sm-shop/src/main/java/com/salesmanager/shop/store/controller/order/facade/OrderFacadeImpl.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/controller/order/facade/OrderFacadeImpl.java
@@ -33,7 +33,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ConversionException;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.catalog.pricing.PricingService;
@@ -403,7 +403,7 @@ public class OrderFacadeImpl implements OrderFacade {
 
 				LOGGER.debug("Validate inventory");
 				for (ProductAvailability availability : product.getAvailabilities()) {
-					if (availability.getRegion().equals(Constants.ALL_REGIONS)) {
+					if (availability.getRegion().equals(CoreBusinessConstants.ALL_REGIONS)) {
 						int qty = availability.getProductQuantity();
 						if (qty < item.getQuantity()) {
 							throw new ServiceException(ServiceException.EXCEPTION_INVENTORY_MISMATCH);

--- a/sm-shop/src/main/java/com/salesmanager/shop/store/controller/store/facade/StoreFacadeImpl.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/controller/store/facade/StoreFacadeImpl.java
@@ -82,7 +82,7 @@ public class StoreFacadeImpl implements StoreFacade {
 	public MerchantStore getByCode(HttpServletRequest request) {
 		String code = request.getParameter("store");
 		if (StringUtils.isEmpty(code)) {
-			code = com.salesmanager.core.business.constants.Constants.DEFAULT_STORE;
+			code = com.salesmanager.core.business.constants.CoreBusinessConstants.DEFAULT_STORE;
 		}
 		return get(code);
 	}

--- a/sm-shop/src/main/java/com/salesmanager/shop/store/facade/product/ProductVariantGroupFacadeImpl.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/facade/product/ProductVariantGroupFacadeImpl.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.business.exception.ServiceException;
 import com.salesmanager.core.business.services.catalog.product.variant.ProductVariantGroupService;
 import com.salesmanager.core.business.services.catalog.product.variant.ProductVariantImageService;
@@ -161,7 +161,7 @@ public class ProductVariantGroupFacadeImpl implements ProductVariantGroupFacade 
 		
 		try {
 			
-			String path = new StringBuilder().append("group").append(Constants.SLASH).append(instanceGroupId).toString();
+			String path = new StringBuilder().append("group").append(CoreBusinessConstants.SLASH).append(instanceGroupId).toString();
 			
 			
 			
@@ -205,7 +205,7 @@ public class ProductVariantGroupFacadeImpl implements ProductVariantGroupFacade 
 
 		
 		try {
-			contentService.removeFile(Constants.SLASH + store.getCode() + Constants.SLASH + productVariantGroupId, FileContentType.VARIANT, image.getProductImage());
+			contentService.removeFile(CoreBusinessConstants.SLASH + store.getCode() + CoreBusinessConstants.SLASH + productVariantGroupId, FileContentType.VARIANT, image.getProductImage());
 			group.getImages().removeIf(i -> (i.getId() == image.getId()));
 			//update productVariantroup
 			productVariantGroupService.update(group);

--- a/sm-shop/src/main/java/com/salesmanager/shop/utils/DateUtil.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/utils/DateUtil.java
@@ -14,7 +14,7 @@
  */
 package com.salesmanager.shop.utils;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +55,7 @@ public class DateUtil {
 
 		if (dt == null)
 			dt = new Date();
-		SimpleDateFormat format = new SimpleDateFormat(Constants.DEFAULT_DATE_FORMAT);
+		SimpleDateFormat format = new SimpleDateFormat(CoreBusinessConstants.DEFAULT_DATE_FORMAT);
 		return format.format(dt);
 
 	}
@@ -64,7 +64,7 @@ public class DateUtil {
 
 		if (dt == null)
 			return null;
-		SimpleDateFormat format = new SimpleDateFormat(Constants.DEFAULT_DATE_FORMAT_YEAR);
+		SimpleDateFormat format = new SimpleDateFormat(CoreBusinessConstants.DEFAULT_DATE_FORMAT_YEAR);
 		return format.format(dt);
 
 	}
@@ -88,13 +88,13 @@ public class DateUtil {
 
 		if (dt == null)
 			return null;
-		SimpleDateFormat format = new SimpleDateFormat(Constants.DEFAULT_DATE_FORMAT);
+		SimpleDateFormat format = new SimpleDateFormat(CoreBusinessConstants.DEFAULT_DATE_FORMAT);
 		return format.format(dt);
 
 	}
 
 	public static Date getDate(String date) throws Exception {
-		DateFormat myDateFormat = new SimpleDateFormat(Constants.DEFAULT_DATE_FORMAT);
+		DateFormat myDateFormat = new SimpleDateFormat(CoreBusinessConstants.DEFAULT_DATE_FORMAT);
 		return myDateFormat.parse(date);
 	}
 
@@ -116,7 +116,7 @@ public class DateUtil {
 
 		Date dt = new Date();
 
-		SimpleDateFormat format = new SimpleDateFormat(Constants.DEFAULT_DATE_FORMAT);
+		SimpleDateFormat format = new SimpleDateFormat(CoreBusinessConstants.DEFAULT_DATE_FORMAT);
 		return format.format(new Date(dt.getTime()));
 	}
 
@@ -149,7 +149,7 @@ public class DateUtil {
 
 	public void processPostedDates(HttpServletRequest request) {
 		Date dt = new Date();
-		DateFormat myDateFormat = new SimpleDateFormat(Constants.DEFAULT_DATE_FORMAT);
+		DateFormat myDateFormat = new SimpleDateFormat(CoreBusinessConstants.DEFAULT_DATE_FORMAT);
 		Date sDate = null;
 		Date eDate = null;
 		try {

--- a/sm-shop/src/main/java/com/salesmanager/shop/utils/LanguageUtils.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/utils/LanguageUtils.java
@@ -1,6 +1,6 @@
 package com.salesmanager.shop.utils;
 
-import static com.salesmanager.core.business.constants.Constants.DEFAULT_STORE;
+import static com.salesmanager.core.business.constants.CoreBusinessConstants.DEFAULT_STORE;
 
 import java.util.Locale;
 import java.util.Optional;

--- a/sm-shop/src/main/java/com/salesmanager/shop/utils/LocaleUtils.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/utils/LocaleUtils.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.model.merchant.MerchantStore;
 import com.salesmanager.core.model.reference.language.Language;
 
@@ -28,7 +28,7 @@ public class LocaleUtils {
 	 */
 	public static Locale getLocale(MerchantStore store) {
 
-		Locale defaultLocale = Constants.DEFAULT_LOCALE;
+		Locale defaultLocale = CoreBusinessConstants.DEFAULT_LOCALE;
 		Locale[] locales = Locale.getAvailableLocales();
 		for(int i = 0; i< locales.length; i++) {
 			Locale l = locales[i];

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/common/ServicesTestSupport.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/common/ServicesTestSupport.java
@@ -23,7 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.shop.application.ShopApplication;
 import com.salesmanager.shop.model.catalog.category.Category;
 import com.salesmanager.shop.model.catalog.category.CategoryDescription;
@@ -66,7 +66,7 @@ public class ServicesTestSupport {
 
 	public ReadableMerchantStore fetchStore() {
 		final HttpEntity<String> httpEntity = new HttpEntity<>(getHeader());
-		return testRestTemplate.exchange(String.format("/api/v1/store/%s", Constants.DEFAULT_STORE), HttpMethod.GET,
+		return testRestTemplate.exchange(String.format("/api/v1/store/%s", CoreBusinessConstants.DEFAULT_STORE), HttpMethod.GET,
 				httpEntity, ReadableMerchantStore.class).getBody();
 
 	}
@@ -192,7 +192,7 @@ public class ServicesTestSupport {
 		final HttpEntity<PersistableCategory> categoryEntity = new HttpEntity<>(newCategory, getHeader());
 
 		final ResponseEntity<PersistableCategory> categoryResponse = testRestTemplate.postForEntity(
-				"/api/v1/private/category?store=" + Constants.DEFAULT_STORE, categoryEntity, PersistableCategory.class);
+				"/api/v1/private/category?store=" + CoreBusinessConstants.DEFAULT_STORE, categoryEntity, PersistableCategory.class);
 		final PersistableCategory cat = categoryResponse.getBody();
 		assertThat(categoryResponse.getStatusCode(), is(CREATED));
 		assertNotNull(cat.getId());
@@ -220,7 +220,7 @@ public class ServicesTestSupport {
 		final HttpEntity<PersistableProduct> entity = new HttpEntity<>(product, getHeader());
 
 		final ResponseEntity<Entity> response = testRestTemplate.postForEntity(
-				"/api/v1/private/product?store=" + Constants.DEFAULT_STORE, entity, Entity.class);
+				"/api/v1/private/product?store=" + CoreBusinessConstants.DEFAULT_STORE, entity, Entity.class);
 		assertThat(response.getStatusCode(), is(CREATED));
 
 		final HttpEntity<String> httpEntity = new HttpEntity<>(getHeader());

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/category/CategoryManagementAPIIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/category/CategoryManagementAPIIntegrationTest.java
@@ -21,7 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.shop.application.ShopApplication;
 import com.salesmanager.shop.model.catalog.category.Category;
 import com.salesmanager.shop.model.catalog.category.CategoryDescription;
@@ -391,7 +391,7 @@ public class CategoryManagementAPIIntegrationTest extends ServicesTestSupport {
       json = writer.writeValueAsString(product1);
       entity = new HttpEntity<>(json, getHeader());
 
-      response = testRestTemplate.postForEntity("/api/v1/private/product?store=" + Constants.DEFAULT_STORE, entity, PersistableProduct.class);
+      response = testRestTemplate.postForEntity("/api/v1/private/product?store=" + CoreBusinessConstants.DEFAULT_STORE, entity, PersistableProduct.class);
       assertThat(response.getStatusCode(), is(CREATED));
             
       //create second item      
@@ -407,7 +407,7 @@ public class CategoryManagementAPIIntegrationTest extends ServicesTestSupport {
       json = writer.writeValueAsString(product2);
       entity = new HttpEntity<>(json, getHeader());
 
-      response = testRestTemplate.postForEntity("/api/v1/private/product?store=" + Constants.DEFAULT_STORE, entity, PersistableProduct.class);
+      response = testRestTemplate.postForEntity("/api/v1/private/product?store=" + CoreBusinessConstants.DEFAULT_STORE, entity, PersistableProduct.class);
       assertThat(response.getStatusCode(), is(CREATED));
       
       entity = new HttpEntity<>(getHeader());

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/customer/CustomerRegistrationIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/customer/CustomerRegistrationIntegrationTest.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.model.customer.CustomerGender;
 import com.salesmanager.shop.application.ShopApplication;
 import com.salesmanager.shop.model.customer.PersistableCustomer;
@@ -39,7 +39,7 @@ public class CustomerRegistrationIntegrationTest extends ServicesTestSupport {
         billing.setLastName("ccstomer1");
         billing.setCountry("BE");
         testCustomer.setBilling(billing);
-        testCustomer.setStoreCode(Constants.DEFAULT_STORE);
+        testCustomer.setStoreCode(CoreBusinessConstants.DEFAULT_STORE);
         final HttpEntity<PersistableCustomer> entity = new HttpEntity<>(testCustomer, getHeader());
 
         final ResponseEntity<PersistableCustomer> response = testRestTemplate.postForEntity("/api/v1/customer/register", entity, PersistableCustomer.class);

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/product/ProductManagementAPIIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/product/ProductManagementAPIIntegrationTest.java
@@ -26,7 +26,7 @@ import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.core.model.catalog.product.attribute.ProductOptionType;
 import com.salesmanager.shop.application.ShopApplication;
 import com.salesmanager.shop.model.catalog.category.Category;
@@ -84,7 +84,7 @@ public class ProductManagementAPIIntegrationTest extends ServicesTestSupport {
 		final HttpEntity<PersistableCategory> categoryEntity = new HttpEntity<>(newCategory, getHeader());
 
 		final ResponseEntity<PersistableCategory> categoryResponse = testRestTemplate.postForEntity(
-				"/api/v1/private/category?store=" + Constants.DEFAULT_STORE, categoryEntity, PersistableCategory.class);
+				"/api/v1/private/category?store=" + CoreBusinessConstants.DEFAULT_STORE, categoryEntity, PersistableCategory.class);
 		final PersistableCategory cat = categoryResponse.getBody();
 		assertThat(categoryResponse.getStatusCode(), is(CREATED));
 		assertNotNull(cat.getId());
@@ -102,7 +102,7 @@ public class ProductManagementAPIIntegrationTest extends ServicesTestSupport {
 		final HttpEntity<PersistableProduct> entity = new HttpEntity<>(product, getHeader());
 
 		final ResponseEntity<PersistableProduct> response = testRestTemplate.postForEntity(
-				"/api/v1/private/product?store=" + Constants.DEFAULT_STORE, entity, PersistableProduct.class);
+				"/api/v1/private/product?store=" + CoreBusinessConstants.DEFAULT_STORE, entity, PersistableProduct.class);
 		assertThat(response.getStatusCode(), is(CREATED));
 	}
 
@@ -128,7 +128,7 @@ public class ProductManagementAPIIntegrationTest extends ServicesTestSupport {
 		final HttpEntity<PersistableProductReview> entity = new HttpEntity<>(review, getHeader());
 
 		final ResponseEntity<PersistableProductReview> response = testRestTemplate.postForEntity(
-				"/api/v1/private/products/1/reviews?store=" + Constants.DEFAULT_STORE, entity,
+				"/api/v1/private/products/1/reviews?store=" + CoreBusinessConstants.DEFAULT_STORE, entity,
 				PersistableProductReview.class);
 
 		final PersistableProductReview rev = response.getBody();

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/product/ProductV2ManagementAPIIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/product/ProductV2ManagementAPIIntegrationTest.java
@@ -16,7 +16,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.shop.application.ShopApplication;
 import com.salesmanager.shop.model.catalog.category.Category;
 import com.salesmanager.shop.model.catalog.category.CategoryDescription;
@@ -67,7 +67,7 @@ public class ProductV2ManagementAPIIntegrationTest extends ServicesTestSupport {
 		final HttpEntity<PersistableCategory> categoryEntity = new HttpEntity<>(newCategory, getHeader());
 
 		final ResponseEntity<PersistableCategory> categoryResponse = testRestTemplate.postForEntity(
-				"/api/v1/private/category?store=" + Constants.DEFAULT_STORE, categoryEntity, PersistableCategory.class);
+				"/api/v1/private/category?store=" + CoreBusinessConstants.DEFAULT_STORE, categoryEntity, PersistableCategory.class);
 		final PersistableCategory cat = categoryResponse.getBody();
 		assertTrue(categoryResponse.getStatusCode()== CREATED);
 		assertNotNull(cat.getId());
@@ -84,7 +84,7 @@ public class ProductV2ManagementAPIIntegrationTest extends ServicesTestSupport {
 		
 		final HttpEntity<PersistableProduct> productEntity = new HttpEntity<>(product, getHeader());
 		final ResponseEntity<PersistableProduct> response = testRestTemplate.postForEntity(
-				"/api/v2/private/product?store=" + Constants.DEFAULT_STORE, productEntity, PersistableProduct.class);
+				"/api/v2/private/product?store=" + CoreBusinessConstants.DEFAULT_STORE, productEntity, PersistableProduct.class);
 		assertTrue(response.getStatusCode()== CREATED);
 		
 		//create options
@@ -97,7 +97,7 @@ public class ProductV2ManagementAPIIntegrationTest extends ServicesTestSupport {
 		
 		final HttpEntity<PersistableProductOption> colorEntity = new HttpEntity<>(color, getHeader());
 		final ResponseEntity<PersistableProductOption> colorResponse = testRestTemplate.postForEntity(
-				"/api/v1/private/product/option?store=" + Constants.DEFAULT_STORE, colorEntity, PersistableProductOption.class);
+				"/api/v1/private/product/option?store=" + CoreBusinessConstants.DEFAULT_STORE, colorEntity, PersistableProductOption.class);
 		assertTrue(colorResponse.getStatusCode()== CREATED);
 		System.out.println(colorResponse.getBody().getId());
 		
@@ -111,7 +111,7 @@ public class ProductV2ManagementAPIIntegrationTest extends ServicesTestSupport {
 		
 		final HttpEntity<PersistableProductOption> sizeEntity = new HttpEntity<>(size, getHeader());
 		final ResponseEntity<PersistableProductOption> sizeResponse = testRestTemplate.postForEntity(
-				"/api/v1/private/product/option?store=" + Constants.DEFAULT_STORE, sizeEntity, PersistableProductOption.class);
+				"/api/v1/private/product/option?store=" + CoreBusinessConstants.DEFAULT_STORE, sizeEntity, PersistableProductOption.class);
 		assertTrue(sizeResponse.getStatusCode()== CREATED);
 		System.out.println(colorResponse.getBody().getId());
 		
@@ -125,7 +125,7 @@ public class ProductV2ManagementAPIIntegrationTest extends ServicesTestSupport {
 		
 		final HttpEntity<PersistableProductOptionValue> whiteEntity = new HttpEntity<>(white, getHeader());
 		final ResponseEntity<PersistableProductOptionValue> whiteResponse = testRestTemplate.postForEntity(
-				"/api/v1/private/product/option?store=" + Constants.DEFAULT_STORE, whiteEntity, PersistableProductOptionValue.class);
+				"/api/v1/private/product/option?store=" + CoreBusinessConstants.DEFAULT_STORE, whiteEntity, PersistableProductOptionValue.class);
 		assertTrue(whiteResponse.getStatusCode()== CREATED);
 		System.out.println(whiteResponse.getBody().getId());
 		

--- a/sm-shop/src/test/java/com/salesmanager/test/shop/integration/search/SearchApiIntegrationTest.java
+++ b/sm-shop/src/test/java/com/salesmanager/test/shop/integration/search/SearchApiIntegrationTest.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.salesmanager.core.business.constants.Constants;
+import com.salesmanager.core.business.constants.CoreBusinessConstants;
 import com.salesmanager.shop.application.ShopApplication;
 import com.salesmanager.shop.model.catalog.SearchProductList;
 import com.salesmanager.shop.model.catalog.SearchProductRequest;
@@ -46,7 +46,7 @@ public class SearchApiIntegrationTest extends ServicesTestSupport {
     	
         final HttpEntity<PersistableProduct> entity = new HttpEntity<>(product, getHeader());
 
-        final ResponseEntity<PersistableProduct> response = testRestTemplate.postForEntity("/api/v1/private/product?store=" + Constants.DEFAULT_STORE, entity, PersistableProduct.class);
+        final ResponseEntity<PersistableProduct> response = testRestTemplate.postForEntity("/api/v1/private/product?store=" + CoreBusinessConstants.DEFAULT_STORE, entity, PersistableProduct.class);
         assertThat(response.getStatusCode(), is(CREATED));
         
         SearchProductRequest searchRequest = new SearchProductRequest();
@@ -54,7 +54,7 @@ public class SearchApiIntegrationTest extends ServicesTestSupport {
         final HttpEntity<SearchProductRequest> searchEntity = new HttpEntity<>(searchRequest, getHeader());
         
         
-        final ResponseEntity<SearchProductList> searchResponse = testRestTemplate.postForEntity("/api/v1/search?store=" + Constants.DEFAULT_STORE, searchEntity, SearchProductList.class);
+        final ResponseEntity<SearchProductList> searchResponse = testRestTemplate.postForEntity("/api/v1/search?store=" + CoreBusinessConstants.DEFAULT_STORE, searchEntity, SearchProductList.class);
         assertThat(searchResponse.getStatusCode(), is(CREATED));
 
     }


### PR DESCRIPTION
### Why
Reduce boilerplate and improve maintainability by using Lombok for entity classes and centralizing constants.

### Changes
- Replaced manual getters/setters in CatalogEntity, CodeEntity, NameEntity, etc. with Lombok annotations
- Added constants package for table names
- Updated POMs to include Lombok and Lombok-MapStruct binding

### Impact
- Cleaner, more maintainable codebase
- Reduced duplication → faster development
- Centralized constants → safer schema/table references
- Backward compatible → no runtime behavior change
