### PR TITLE
docs: replace deprecated git protocol with https in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Get the source code:
 -------------------
 Clone the repository:
      
-	 $ git clone git://github.com/shopizer-ecommerce/shopizer.git
+	 $ git clone https://github.com/shopizer-ecommerce/shopizer.git
 	 
 
 To build the application:


### PR DESCRIPTION
The Git protocol (git://) has been deprecated by GitHub since 2021 and no longer works. 
This updates the README to use HTTPS which is the current recommended method for cloning repositories.

Changes:
- Replaced `git://github.com/` with `https://github.com/` in README.md