### PR TITLE
fix(api): enforce customer ownership validation in order list

### DIFF
--- a/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/order/OrderApi.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/order/OrderApi.java
@@ -121,6 +121,13 @@ public class OrderApi {
 
 		Customer customer = customerService.getById(id);
 
+		// [Security Fix] Ensure authenticated user can only access their own orders
+		com.salesmanager.shop.model.customer.ReadableCustomer authCustomer = customerFacade.getAuthenticatedCustomer();
+		if (authCustomer != null && !authCustomer.getId().equals(id)) {
+			response.sendError(403, "Access Denied: You can only view your own order history.");
+			return null;
+		}
+
 		if (customer == null) {
 			LOGGER.error("Customer is null for id " + id);
 			response.sendError(404, "Customer is null for id " + id);


### PR DESCRIPTION
### Summary
This PR adds a server-side ownership check to the customer order list endpoint.

### Changes
- Verified that the `id` path variable matches the `id` of the authenticated customer.
- Returns a 403 Forbidden error if a mismatch is detected.

This change ensures data privacy and prevents unauthorized access to order history.