### PR TITLE
Add Docker Compose setup with MySQL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Copy this file to .env and adjust the values before running docker compose.
+# NOTE: these are example values for local development only.
+# Never commit a real .env file or reuse these passwords in production.
+
+# --- MySQL ---
+MYSQL_ROOT_PASSWORD=change-me-root-password
+MYSQL_DATABASE=SALESMANAGER
+MYSQL_USER=shopizer
+MYSQL_PASSWORD=change-me-shopizer-password
+MYSQL_PORT=3306
+
+# --- Shopizer headless API (Java backend) ---
+SHOPIZER_API_PORT=8080
+
+# --- Shopizer admin UI ---
+SHOPIZER_ADMIN_PORT=82
+# URL the admin UI (running in the browser) uses to reach the API
+ADMIN_APP_BASE_URL=http://localhost:8080/api
+
+# --- React sample shop ---
+SHOPIZER_SHOP_PORT=80
+APP_MERCHANT=DEFAULT
+# URL the shop (running in the browser) uses to reach the API
+SHOP_APP_BASE_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ sm-shop/src/main/resources/database.properties
 .DS_Store
 
 .mvnw/*.jar
+
+# local docker compose environment
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+
+
+# Shopizer full stack: MySQL + Headless API + Admin + React sample shop
+#
+# 1. Copy .env.example to .env and adjust values if needed
+# 2. Run: docker compose up -d
+# 3. See docs/DOCKER_SETUP.md for details
+#
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: shopizer-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root-password}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-SALESMANAGER}
+      MYSQL_USER: ${MYSQL_USER:-shopizer}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-shopizer-password}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    ports:
+      - "${MYSQL_PORT:-3306}:3306"
+    volumes:
+      - shopizer-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  shopizer:
+    image: shopizerecomm/shopizer:latest
+    container_name: shopizer-api
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+    # The mysql Spring profile loads profiles/mysql/database.properties,
+    # which leaves db.jdbcUrl / db.user / db.password unset so they can be
+    # supplied as JVM system properties (PropertyPlaceholderConfigurer
+    # falls back to system properties).
+    command:
+      - java
+      - -Dspring.profiles.active=mysql
+      - "-Ddb.jdbcUrl=jdbc:mysql://mysql:3306/${MYSQL_DATABASE:-SALESMANAGER}?autoReconnect=true&serverTimezone=UTC&useUnicode=true&characterEncoding=UTF-8"
+      - -Ddb.user=${MYSQL_USER:-shopizer}
+      - -Ddb.password=${MYSQL_PASSWORD:-shopizer-password}
+      - -Delasticsearch.security.password=NO
+      - -jar
+      - /opt/app/shopizer.jar
+    ports:
+      - "${SHOPIZER_API_PORT:-8080}:8080"
+
+  shopizer-admin:
+    image: shopizerecomm/shopizer-admin:latest
+    container_name: shopizer-admin
+    restart: unless-stopped
+    depends_on:
+      - shopizer
+    environment:
+      APP_BASE_URL: ${ADMIN_APP_BASE_URL:-http://localhost:8080/api}
+    ports:
+      - "${SHOPIZER_ADMIN_PORT:-82}:80"
+
+  shopizer-shop:
+    image: shopizerecomm/shopizer-shop-reactjs:latest
+    container_name: shopizer-shop
+    restart: unless-stopped
+    depends_on:
+      - shopizer
+    environment:
+      APP_MERCHANT: ${APP_MERCHANT:-DEFAULT}
+      APP_BASE_URL: ${SHOP_APP_BASE_URL:-http://localhost:8080}
+    ports:
+      - "${SHOPIZER_SHOP_PORT:-80}:80"
+
+volumes:
+  shopizer-mysql-data:

--- a/docs/DOCKER_SETUP.md
+++ b/docs/DOCKER_SETUP.md
@@ -1,0 +1,107 @@
+# Running Shopizer with Docker Compose (MySQL)
+
+This guide describes how to run the complete Shopizer stack locally with a
+single command using Docker Compose:
+
+| Service         | Image                                   | Default URL              |
+|-----------------|------------------------------------------|--------------------------|
+| MySQL 8         | `mysql:8.0`                              | `localhost:3306`         |
+| Headless API    | `shopizerecomm/shopizer`                 | http://localhost:8080    |
+| Admin UI        | `shopizerecomm/shopizer-admin`           | http://localhost:82      |
+| React shop      | `shopizerecomm/shopizer-shop-reactjs`    | http://localhost:80      |
+
+By default the Shopizer backend runs against an embedded H2 database. The
+`docker-compose.yml` at the root of this repository instead activates the
+`mysql` Spring profile and points the backend at a MySQL 8 container, which
+is closer to a production-like environment.
+
+## Prerequisites
+
+- Docker Engine 20.10+ and Docker Compose v2 (`docker compose` command)
+- Ports 80, 82, 3306 and 8080 available (all configurable, see below)
+
+## Quick start
+
+```
+cp .env.example .env
+# edit .env and set your own passwords
+docker compose up -d
+```
+
+The first startup takes a few minutes: MySQL initializes, then the backend
+creates the schema in the `SALESMANAGER` database
+(`hibernate.hbm2ddl.auto=update`).
+
+Verify everything is up:
+
+```
+docker compose ps
+docker compose logs -f shopizer
+```
+
+Then open:
+
+- Swagger / headless API: http://localhost:8080/swagger-ui.html
+- Admin UI: http://localhost:82 (default credentials: `admin@shopizer.com` / `password`)
+- React sample shop: http://localhost:80
+
+## How the MySQL integration works
+
+The backend image runs `java -jar /opt/app/shopizer.jar`. The compose file
+overrides that command to:
+
+1. Activate the `mysql` Spring profile (`-Dspring.profiles.active=mysql`),
+   which makes Shopizer load `profiles/mysql/database.properties` and the
+   MySQL JDBC driver/Hibernate dialect configured there.
+2. Supply the connection settings as JVM system properties
+   (`-Ddb.jdbcUrl`, `-Ddb.user`, `-Ddb.password`). These placeholders are
+   intentionally left unset in the profile's properties file and are
+   resolved from system properties at startup.
+
+The JDBC URL uses the compose service name `mysql` as hostname, so no extra
+network configuration is required.
+
+## Configuration
+
+All settings live in `.env` (see `.env.example` for the full list):
+
+- `MYSQL_*` — database name, credentials and host port
+- `SHOPIZER_API_PORT`, `SHOPIZER_ADMIN_PORT`, `SHOPIZER_SHOP_PORT` — host ports
+- `ADMIN_APP_BASE_URL`, `SHOP_APP_BASE_URL` — the URLs the admin UI and shop
+  (running in your browser) use to call the API. If you change
+  `SHOPIZER_API_PORT`, update these accordingly.
+
+## Data persistence
+
+MySQL data is stored in the named volume `shopizer-mysql-data` and survives
+`docker compose down`. To start from a clean database:
+
+```
+docker compose down -v
+```
+
+## Troubleshooting
+
+- **Backend restarts / cannot connect to MySQL**: the backend waits for the
+  MySQL healthcheck, but on slow machines the first schema creation can take
+  a while. Check `docker compose logs shopizer`.
+- **Port already in use**: change the corresponding `*_PORT` variable in
+  `.env`.
+- **Admin or shop cannot reach the API**: make sure `ADMIN_APP_BASE_URL` /
+  `SHOP_APP_BASE_URL` point to a URL reachable from your browser (not the
+  internal service name).
+
+  Note: the published image's mysql profile does not define elasticsearch.security.password, so the compose file passes -Delasticsearch.security.password=NO. The value is unused because elasticsearch.security.enabled=false, but without it the API fails at startup with "Could not resolve placeholder 'elasticsearch.security.password'".
+
+## Building the backend image locally (optional)
+
+To run your own build instead of the published image:
+
+```
+./mvnw clean install -DskipTests
+cd sm-shop
+docker build -t shopizer:local .
+```
+
+Then replace `image: shopizerecomm/shopizer:latest` with `image: shopizer:local`
+in `docker-compose.yml`.


### PR DESCRIPTION
Adds a one-command local deployment of the full Shopizer stack (MySQL 8 + headless API + admin UI + React sample shop):

- docker-compose.yml: runs the backend with the 'mysql' Spring profile and injects db.jdbcUrl/db.user/db.password as JVM system properties, resolved by the profile's placeholder configuration
- .env.example: documented environment variable template
- docs/DOCKER_SETUP.md: setup, configuration and troubleshooting guide
- .gitignore: ignore local .env files
- Tested with `docker compose up` in GitHub Codespaces: all four containers start, the API connects to MySQL, initializes the SALESMANAGER schema with seed data, and serves requests on port 8080.
- Note: the published image's mysql profile does not define `elasticsearch.security.password`, so the compose file supplies it as a JVM system property (unused since `elasticsearch.security.enabled=false`) — without it the API fails at startup. This is documented in docs/DOCKER_SETUP.md.

Fixes #1085