### PR TITLE
Fix: removed hardcoded JWT secret,use environment variable

### DIFF
--- a/sm-core/src/main/resources/authentication.properties
+++ b/sm-core/src/main/resources/authentication.properties
@@ -3,7 +3,7 @@ authToken.header=Authorization
 
 #JWT authentication configuration for sm-shop
 jwt.header=Authorization
-jwt.secret=aSecret
+jwt.secret=${JWT_SECRET}
 jwt.expiration= 604800
 
 


### PR DESCRIPTION
Fixes #1108

The JWT secret was hardcoded (`jwt.secret=aSecret`) in `authentication.properties`, 
which is visible to anyone browsing the public repository. Since this secret signs JWTs, 
anyone could forge valid tokens for any user and also impersonating arbitrary users.

I have changed it to pull from an environment variable instead:

jwt.secret=${JWT_SECRET}

No default value is provided, so the application will fail to start unless a JWT_SECRET 
environment variable is explicitly set by whoever runs the app. This prevents 
silently falling back to an insecure default.

Note: anyone deploying this app now needs to set JWT_SECRET (a long, random 
string) as an environment variable before starting the app.

Tested locally: the app starts fine with JWT_SECRET set, but would fail without it.