### PR TITLE
Fix customer resource ownership checks

### DIFF
--- a/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/order/OrderApi.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/order/OrderApi.java
@@ -369,6 +369,11 @@ public class OrderApi {
 				throw new ResourceNotFoundException("Cart code " + code + " does not exist");
 			}
 
+			if (cart.getCustomerId() != null && !cart.getCustomerId().equals(customer.getId())) {
+				response.sendError(404, "Cart code " + code + " does not exist");
+				return null;
+			}
+
 			order.setShoppingCartId(cart.getId());
 			order.setCustomerId(customer.getId());//That is an existing customer purchasing
 

--- a/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/product/ProductReviewApi.java
+++ b/sm-shop/src/main/java/com/salesmanager/shop/store/api/v1/product/ProductReviewApi.java
@@ -1,5 +1,6 @@
 package com.salesmanager.shop.store.api.v1.product;
 
+import java.security.Principal;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -20,8 +21,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.salesmanager.core.business.services.catalog.product.ProductService;
 import com.salesmanager.core.business.services.catalog.product.review.ProductReviewService;
+import com.salesmanager.core.business.services.customer.CustomerService;
 import com.salesmanager.core.model.catalog.product.Product;
 import com.salesmanager.core.model.catalog.product.review.ProductReview;
+import com.salesmanager.core.model.customer.Customer;
 import com.salesmanager.core.model.merchant.MerchantStore;
 import com.salesmanager.core.model.reference.language.Language;
 import com.salesmanager.shop.constants.Constants;
@@ -42,6 +45,8 @@ public class ProductReviewApi {
   @Inject private ProductService productService;
 
   @Inject private ProductReviewService productReviewService;
+
+  @Inject private CustomerService customerService;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProductReviewApi.class);
 
@@ -68,6 +73,16 @@ public class ProductReviewApi {
       HttpServletResponse response) {
 
     try {
+      if (request.isUserInRole(Constants.PERMISSION_CUSTOMER_AUTHENTICATED)) {
+        Principal principal = request.getUserPrincipal();
+        Customer customer = principal == null ? null : customerService.getByNick(principal.getName());
+        if (customer == null) {
+          response.sendError(401, "Customer not authorized");
+          return null;
+        }
+        review.setCustomerId(customer.getId());
+      }
+
       // rating already exist
       ProductReview prodReview =
           productReviewService.getByProductAndCustomer(


### PR DESCRIPTION
## Summary

- Verify that an authenticated customer can only check out a non-guest shopping cart belonging to that customer.
- Resolve the customer ID for `/api/v1/auth/products/{id}/reviews` from the authenticated principal instead of trusting the request body.
- Preserve the existing administrator `/api/v1/private/products/{id}/reviews` workflow.

Fixes #1112

## Testing

- `./mvnw -B -DskipTests clean compile` — passed for the full Maven reactor after dependency resolution through a temporary Maven Central mirror.
- `ProductManagementAPIIntegrationTest` — passed: 7 tests, 0 failures, 0 errors; 6 existing tests skipped by `@Ignore`.
- `ShoppingCartAPIIntegrationTest` — passed: 7 tests, 0 failures, 0 errors.

The first direct Maven attempt stopped during dependency resolution because the configured Sonatype endpoint was unavailable; the same build completed successfully with the temporary mirror.
